### PR TITLE
Add a list command

### DIFF
--- a/pkg/configs/global.go
+++ b/pkg/configs/global.go
@@ -24,7 +24,7 @@ type GithubConfig struct {
 }
 
 type OptionsConfig struct {
-	LogLevel                         string `fig:"log_level"`
+	LogLevel                         string `fig:"log_level" default:"info"`
 	AssignCodeReviewerIfNoneAssigned bool   `fig:"assign_code_reviewer_if_none_assigned"`
 	ShowGitOutput                    bool   `fig:"show_git_output"`
 

--- a/pkg/core/list.go
+++ b/pkg/core/list.go
@@ -1,0 +1,58 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	header = "state\tmergeable_state\thtml_url"
+)
+
+// Perform a migration
+func (b *Banshee) List(state string, format string) error {
+
+	b.log = logrus.WithField("command", "migrate")
+
+	if validationErr := b.validateMigrateCommand(); validationErr != nil {
+		return validationErr
+	}
+
+	prList, prListErr := b.GithubClient.GetMatchingPRs(b.formatPRQuery(state))
+	if prListErr != nil {
+		return prListErr
+	}
+
+	switch format {
+	case "json":
+		jsonOutput, jsonErr := json.Marshal(prList)
+		if jsonErr != nil {
+			return jsonErr
+		}
+
+		fmt.Println(string(jsonOutput))
+	default:
+		w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+		fmt.Fprintln(w, header)
+		for _, pr := range prList {
+			line := strings.Join([]string{*pr.State, *pr.MergeableState, *pr.HTMLURL}, "\t")
+			fmt.Fprintln(w, line)
+		}
+		w.Flush()
+	}
+
+	return nil
+}
+
+func (b *Banshee) formatPRQuery(state string) string {
+	stateQuery := ""
+	if state != "all" {
+		stateQuery = fmt.Sprintf("state:%s", state)
+	}
+	return fmt.Sprintf("is:pr org:%s head:%s %s", b.getOrgName(), b.MigrationConfig.BranchName, stateQuery)
+}

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -55,13 +55,19 @@ func (b *Banshee) validateMigrateCommand() error {
 	return nil
 }
 
-// Handle setting defaults for the migration options
-func (b *Banshee) migrationOptions() (string, []string, error) {
+func (b *Banshee) getOrgName() string {
 	org := b.MigrationConfig.Organisation
 	if b.MigrationConfig.Organisation == "" {
 		org = b.GlobalConfig.Defaults.Organisation
 		b.log.Debug("No organisation chosen, using ", org)
 	}
+
+	return org
+}
+
+// Handle setting defaults for the migration options
+func (b *Banshee) migrationOptions() (string, []string, error) {
+	org := b.getOrgName()
 
 	if len(b.MigrationConfig.ListOfRepos) > 0 {
 		return org, b.MigrationConfig.ListOfRepos, nil


### PR DESCRIPTION
# What

* Add a `list <path>` command

# Why

This lists out every PR associated with a migration by matching the organisation and `HEAD` branch name. 

The command has a summary format that only prints out some info about state and a URL, but there's also a JSON format option that outputs the full PR data for each PR. Hopefully the JSON option will give folks the customisability through something like `jq` to output any format or data they need.