### PR TITLE
Don't hardcode log level

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -9,10 +9,6 @@ import (
 	localGH "github.com/thejokersthief/banshee/pkg/github"
 )
 
-func init() {
-	logrus.SetLevel(logrus.DebugLevel)
-}
-
 type Banshee struct {
 	GlobalConfig    *configs.GlobalConfig
 	MigrationConfig *configs.MigrationConfig


### PR DESCRIPTION
# What

* Remove log level hardcoded to Debug in `init()`

# Why

When I rewrote the log level to be configurable, I forgot to also remove the hardcoded call to set it.