### PR TITLE
Distinguish between closed and merged

### DIFF
--- a/pkg/core/list.go
+++ b/pkg/core/list.go
@@ -40,7 +40,12 @@ func (b *Banshee) List(state string, format string) error {
 		w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
 		fmt.Fprintln(w, header)
 		for _, pr := range prList {
-			line := strings.Join([]string{*pr.State, *pr.MergeableState, *pr.HTMLURL}, "\t")
+			state := *pr.State
+			if *pr.Merged {
+				state = "merged"
+			}
+
+			line := strings.Join([]string{state, *pr.MergeableState, *pr.HTMLURL}, "\t")
 			fmt.Fprintln(w, line)
 		}
 		w.Flush()


### PR DESCRIPTION
# What

* Add a "merged" state to the list summary output

# Why

GitHub doesn't distinguish between closed and merged in the state field. So if something is closed and has `merged = true`, it's been merged.