### PR TITLE
Add clone command to preclone repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ out
 # Local
 *.test.yaml
 repos.cache/
+*.pem

--- a/README.md
+++ b/README.md
@@ -41,10 +41,20 @@ Commands:
   merge <path>
     Merge PRs not blocked by any branch protections
 
+  clone <path>
+    Clone all of the repositories that are going to be involved in a migration
+
 Run "main <command> --help" for more information on a command.
 ```
 
 ## Examples
+
+### Pre-cloning repos for migration
+
+```bash
+banshee clone examples/migration_config/migration.yaml \
+    --config examples/global_config/config.yaml \
+```
 
 ### Running a migration
 
@@ -58,6 +68,7 @@ banshee migrate examples/migration_config/migration.yaml \
 ```bash
 banshee list examples/migration_config/migration.yaml \
     --config examples/global_config/config.yaml \
+    --state all \
     --format json
 ```
 

--- a/cmd/banshee/main.go
+++ b/cmd/banshee/main.go
@@ -39,6 +39,10 @@ var CLI struct {
 		MigrationFile string `arg:"" name:"path" help:"Path to migration file." type:"path"`
 	} `cmd:"" help:"Merge PRs not blocked by any branch protections"`
 
+	Clone struct {
+		MigrationFile string `arg:"" name:"path" help:"Path to migration file." type:"path"`
+	} `cmd:"" help:"Clone all of the repositories that are going to be involved in a migration"`
+
 	ConfigFile string `name:"config" short:"c" help:"Path to global CLI config" type:"path" default:"./config.yaml"`
 }
 
@@ -66,6 +70,10 @@ func main() {
 		banshee := createBanshee(globalConfig, CLI.Merge.MigrationFile)
 		mergeErr := banshee.MergeApproved()
 		handleErr(mergeErr)
+	case "clone <path>":
+		banshee := createBanshee(globalConfig, CLI.Clone.MigrationFile)
+		cloneErr := banshee.Clone()
+		handleErr(cloneErr)
 	default:
 		printFatalError(fmt.Errorf(ctx.Command()))
 	}

--- a/pkg/core/clone.go
+++ b/pkg/core/clone.go
@@ -1,0 +1,38 @@
+package core
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Perform a migration
+func (b *Banshee) Clone() error {
+
+	b.log = logrus.WithField("command", "clone")
+
+	if !b.GlobalConfig.Options.CacheRepos.Enabled {
+		return errors.New("Please set options.cache.enabled to `true` if you want to preclone all the repos")
+	}
+
+	if validationErr := b.validateMigrateCommand(); validationErr != nil {
+		return validationErr
+	}
+
+	if cacheErr := b.CreateCacheRepoIfEnabled(); cacheErr != nil {
+		return cacheErr
+	}
+
+	org, repos, optionsErr := b.migrationOptions()
+	if optionsErr != nil {
+		return optionsErr
+	}
+
+	for _, repo := range repos {
+		_, _, _, cloneErr := b.cloneRepo(b.log, org, repo)
+		if cloneErr != nil {
+			return cloneErr
+		}
+	}
+	return nil
+}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -40,7 +40,7 @@ func NewGithubClient(globalConf configs.GlobalConfig, ctx context.Context, log *
 
 	var showOutput sideband.Progress
 	if globalConf.Options.ShowGitOutput {
-		showOutput = log.Writer()
+		showOutput = os.Stdout
 	}
 
 	ghClient := &GithubClient{


### PR DESCRIPTION
# What

* Add a command to pre-clone all repos for a migration
* Switch to using `os.Stdout` for the git output

# Why

For the git output, `os.Stdout` gives a live update. Whereas `logrus.Writer()` only updates at the end the output.

For the pre-clone command, it can be useful to pull down every repo you're going to be running the migration on, to speed up the migration action itself. Seemed like a nice quality of life improvement for folks wanting to even test what repos get matched by their query.