### PR TITLE
Fix pushes by removing references and checking out if already exists

### DIFF
--- a/pkg/actions/replace.go
+++ b/pkg/actions/replace.go
@@ -39,7 +39,7 @@ func NewReplaceAction(dir string, description string, input map[string]string) *
 }
 
 func (r *Replace) Run(log *logrus.Entry) error {
-	log.Debug("Replacing ", r.OldString, " with ", r.NewString)
+	log.Debug("Replace action: ", r.OldString, " --> ", r.NewString)
 
 	files := make(chan string)
 	errChan := make(chan error)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -19,14 +19,16 @@ type Banshee struct {
 }
 
 func NewBanshee(config configs.GlobalConfig, migConfig configs.MigrationConfig) (*Banshee, error) {
-	logger := logrus.New()
 
 	lvl, lvlErr := logrus.ParseLevel(config.Options.LogLevel)
 	if lvlErr != nil {
 		return nil, lvlErr
 	}
 	logrus.SetLevel(lvl)
+
+	logger := logrus.New()
 	log := logger.WithField("command", "unset")
+	log.Logger.SetLevel(lvl)
 
 	ctx := context.Background()
 	client, err := localGH.NewGithubClient(config, ctx, log)

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -175,7 +175,7 @@ func (b *Banshee) pushChanges(changelog []string, gitRepo *git.Repository, org, 
 	if prErr != nil {
 		return "", prErr
 	}
-	log.Debug("Got PR result: ", pr)
+	log.Debug("Got PR result: ", pr != nil)
 
 	prBody, bodyErr := b.formatChangelog(pr, changelog)
 	if bodyErr != nil {

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -12,6 +12,13 @@ import (
 
 const defaultRemote = "origin"
 
+func (gc *GithubClient) auth() *gitHttp.BasicAuth {
+	return &gitHttp.BasicAuth{
+		Username: "placeholderUsername", // anything except an empty string
+		Password: gc.accessToken,
+	}
+}
+
 // Checkout a local branch, switching the working tree
 func (gc *GithubClient) Checkout(branch string, gitRepo *git.Repository, create bool) error {
 	wt, wtErr := gitRepo.Worktree()
@@ -48,10 +55,7 @@ func (gc *GithubClient) Fetch(branch string, gitRepo *git.Repository) error {
 	gc.log.Debug("Fetching references for ", plumbing.NewBranchReferenceName(branch))
 	fetchErr := gitRepo.Fetch(&git.FetchOptions{
 		Progress: gc.Writer,
-		Auth: &gitHttp.BasicAuth{
-			Username: "placeholderUsername", // anything except an empty string
-			Password: gc.accessToken,
-		},
+		Auth:     gc.auth(),
 		RefSpecs: []config.RefSpec{
 			config.RefSpec(plumbing.NewBranchReferenceName(branch) + ":" + plumbing.NewRemoteReferenceName(defaultRemote, branch)),
 		},
@@ -75,11 +79,8 @@ func (gc *GithubClient) Pull(branch string, gitRepo *git.Repository) error {
 		Progress:      gc.Writer,
 		RemoteName:    "origin",
 		ReferenceName: plumbing.NewBranchReferenceName(branch),
-		Auth: &gitHttp.BasicAuth{
-			Username: "placeholderUsername", // anything except an empty string
-			Password: gc.accessToken,
-		},
-		SingleBranch: true,
+		Auth:          gc.auth(),
+		SingleBranch:  true,
 	})
 
 	if pullErr != nil && (!errors.Is(pullErr, git.NoErrAlreadyUpToDate) && pullErr.Error() != "reference not found") {

--- a/pkg/github/pull_requests.go
+++ b/pkg/github/pull_requests.go
@@ -4,6 +4,7 @@ package github
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/google/go-github/v52/github"
@@ -42,6 +43,9 @@ func (gc *GithubClient) CreatePullRequest(org, repo, title, body, base_branch, m
 		var errResponse *github.ErrorResponse
 		ghErr := errors.As(err, &errResponse)
 		if ghErr {
+			if strings.Contains(errResponse.Errors[0].Message, "No commits between") {
+				return "", nil
+			}
 			return "", err
 		}
 	}

--- a/pkg/github/pull_requests.go
+++ b/pkg/github/pull_requests.go
@@ -34,15 +34,14 @@ func (gc *GithubClient) CreatePullRequest(org, repo, title, body, base_branch, m
 		Base:                github.String(base_branch),
 		Body:                github.String(body),
 		MaintainerCanModify: github.Bool(true),
-		Draft:               &asDraft,
+		Draft:               github.Bool(asDraft),
 	}
 
 	pr, _, err := gc.Client.PullRequests.Create(gc.ctx, org, repo, newPR)
-
 	if err != nil {
 		var errResponse *github.ErrorResponse
 		ghErr := errors.As(err, &errResponse)
-		if ghErr && errResponse.Message != "Validation Failed" {
+		if ghErr {
 			return "", err
 		}
 	}


### PR DESCRIPTION
# What

* Checkout the branch, even if it exists
* Remove explicit references when pushing to remote
* Add so many more debug logs

# Why

At some point, I broke pushes somehow (???). I'm genuinely confused why this worked for so long but suddenly stopped. Anyway, we get more debug logs out of it