### PR TITLE
Set sensible buffer defaults for find-and-replace

### DIFF
--- a/pkg/actions/replace.go
+++ b/pkg/actions/replace.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strings"
 

--- a/pkg/actions/replace.go
+++ b/pkg/actions/replace.go
@@ -41,8 +41,8 @@ func NewReplaceAction(dir string, description string, input map[string]string) *
 func (r *Replace) Run(log *logrus.Entry) error {
 	log.Debug("Replace action: ", r.OldString, " --> ", r.NewString)
 
-	files := make(chan string)
-	errChan := make(chan error)
+	files := make(chan string, 512)
+	errChan := make(chan error, math.MaxInt8)
 	for workerCount := 0; workerCount < threadCount; workerCount++ {
 		go r.findAndReplaceWorker(log, files, errChan)
 	}

--- a/pkg/core/list.go
+++ b/pkg/core/list.go
@@ -18,13 +18,12 @@ const (
 func (b *Banshee) List(state string, format string) error {
 
 	b.log = logrus.WithField("command", "migrate")
-
 	if validationErr := b.validateMigrateCommand(); validationErr != nil {
 		return validationErr
 	}
 
 	query := b.formatPRQuery(state)
-	b.log.Debug("Getting list of PRs matching: \"", query, "\"")
+	b.log.Info("Getting list of PRs matching: \"", query, "\"")
 	prList, prListErr := b.GithubClient.GetMatchingPRs(query)
 	if prListErr != nil {
 		return prListErr

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -108,7 +108,6 @@ func (b *Banshee) handleRepo(log *logrus.Entry, org, repo string) (string, error
 	repoNameOnly := strings.ReplaceAll(repo, org+"/", "")
 
 	log.Info("Processing ", repo)
-
 	dir, gitRepo, defaultBranch, cloneErr := b.cloneRepo(log, org, repo)
 	if cloneErr != nil {
 		return "", cloneErr

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -98,10 +98,7 @@ func (gc *GithubClient) Push(branch string, gitRepo *git.Repository) error {
 		&git.PushOptions{
 			Progress:   gc.Writer,
 			RemoteName: "origin",
-			Auth: &gitHttp.BasicAuth{
-				Username: "placeholderUsername", // anything except an empty string
-				Password: gc.accessToken,
-			},
+			Auth:       gc.auth(),
 		},
 	)
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/sideband"
-	gitHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-github/v52/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thejokersthief/banshee/pkg/configs"
@@ -117,12 +116,9 @@ func (gc *GithubClient) ShallowClone(org, repoName, dir, migrationBranchName str
 		// If the directory doesn't exist, clone the repo into it
 		gc.log.Info("Cloning ", gitURL, " [", defaultBranch, "]...")
 		repo, plainOpenErr = git.PlainClone(dir, false, &git.CloneOptions{
-			Progress: gc.Writer,
-			URL:      gitURL,
-			Auth: &gitHttp.BasicAuth{
-				Username: "placeholderUsername", // anything except an empty string
-				Password: gc.accessToken,
-			},
+			Progress:      gc.Writer,
+			URL:           gitURL,
+			Auth:          gc.auth(),
 			ReferenceName: plumbing.NewBranchReferenceName(defaultBranch),
 			SingleBranch:  true,
 			// Depth:         1, // Unfortunately there's an issue in go-git that means using depth breaks the working tree

--- a/pkg/github/pull_requests.go
+++ b/pkg/github/pull_requests.go
@@ -117,3 +117,17 @@ func (gc *GithubClient) AssignDefaultReviewer(pr *github.PullRequest) error {
 
 	return nil
 }
+
+func (gc *GithubClient) GetPR(owner, repo string, number int) (*github.PullRequest, error) {
+	var pullRequest *github.PullRequest
+	searchErr := retry.Do(
+		func() error {
+			var err error
+			pullRequest, _, err = gc.Client.PullRequests.Get(gc.ctx, owner, repo, number)
+			return checkIfRecoverable(err)
+		},
+		defaultRetryOptions...,
+	)
+
+	return pullRequest, searchErr
+}

--- a/pkg/github/pull_requests_search.go
+++ b/pkg/github/pull_requests_search.go
@@ -62,7 +62,7 @@ func NewPRDataWorker(client *GithubClient) *PRDataWorker {
 	return &PRDataWorker{
 		client:  client,
 		issues:  make(chan *github.Issue, 64),
-		results: make(chan *github.PullRequest, math.MaxInt32),
+		results: make(chan *github.PullRequest, math.MaxInt32), // This covers 4,294,967,296 PRs. If we ever reach that limit, we'll need to re-evaluate
 		errChan: make(chan error, math.MaxInt32),
 	}
 }

--- a/pkg/github/pull_requests_search.go
+++ b/pkg/github/pull_requests_search.go
@@ -1,0 +1,116 @@
+// Getting repos to perform the code changes in - probably choose between a GitHub search and graphql (?)
+package github
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/google/go-github/v52/github"
+)
+
+func (gc *GithubClient) GetMatchingPRs(query string) ([]*github.PullRequest, error) {
+	prWorker := NewPRDataWorker(gc)
+	pageOpts := github.ListOptions{PerPage: 100}
+	opt := &github.SearchOptions{Sort: "created", Order: "asc", ListOptions: pageOpts}
+
+	prWorker.spawnWorkers()
+	for {
+		var searchResult *github.IssuesSearchResult
+		var resp *github.Response
+		searchErr := retry.Do(
+			func() error {
+				var err error
+				searchResult, resp, err = gc.Client.Search.Issues(gc.ctx, query, opt)
+				return checkIfRecoverable(err)
+			},
+			defaultRetryOptions...,
+		)
+
+		if searchErr != nil {
+			return nil, searchErr
+		}
+
+		// Convert every issue into a pull request
+		for _, issue := range searchResult.Issues {
+			prWorker.issues <- issue
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+	close(prWorker.issues)
+
+	return prWorker.processResults(), prWorker.processErrors()
+}
+
+const (
+	prDataWorkers = 5
+)
+
+type PRDataWorker struct {
+	client  *GithubClient
+	issues  chan *github.Issue
+	results chan *github.PullRequest
+	errChan chan error
+}
+
+func NewPRDataWorker(client *GithubClient) *PRDataWorker {
+	return &PRDataWorker{
+		client:  client,
+		issues:  make(chan *github.Issue, 64),
+		results: make(chan *github.PullRequest, math.MaxInt32),
+		errChan: make(chan error, math.MaxInt32),
+	}
+}
+
+// Spawn workers to process PR data
+func (w *PRDataWorker) spawnWorkers() {
+	for workerIndex := 0; workerIndex < prDataWorkers; workerIndex++ {
+		go w.prDataWorker()
+	}
+}
+
+// Process issues and transform them into PRs
+func (w *PRDataWorker) prDataWorker() {
+	for issue := range w.issues {
+		repoOwner, repoName := w.client.getRepoNameFromURL(*issue.HTMLURL)
+		pullRequest, prErr := w.client.GetPR(repoOwner, repoName, *issue.Number)
+		if prErr != nil {
+			w.errChan <- prErr
+			continue
+		}
+
+		w.results <- pullRequest
+		continue
+	}
+}
+
+// Assemble our pull requests for returning
+func (w *PRDataWorker) processResults() []*github.PullRequest {
+	pullRequests := []*github.PullRequest{}
+	for resultIndex := 0; resultIndex < len(w.results); resultIndex++ {
+		pr := <-w.results
+		pullRequests = append(pullRequests, pr)
+	}
+	close(w.results)
+	return pullRequests
+}
+
+// If there are any errors, join them into a single error and return the error
+func (w *PRDataWorker) processErrors() error {
+	if len(w.errChan) > 0 {
+		finalError := fmt.Errorf("")
+		for i := 0; i < len(w.errChan); i++ {
+			prGetErr := <-w.errChan
+			finalError = errors.Join(finalError, prGetErr)
+		}
+		return finalError
+	}
+	close(w.errChan)
+
+	return nil
+}

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -2,8 +2,6 @@
 package github
 
 import (
-	"strings"
-
 	"github.com/avast/retry-go/v4"
 	"github.com/google/go-github/v52/github"
 )
@@ -75,79 +73,4 @@ func (gc *GithubClient) GetMatchingRepos(query string) ([]string, error) {
 	}
 
 	return removeDuplicateStr(repos), nil
-}
-
-func (gc *GithubClient) GetMatchingPRs(query string) ([]*github.PullRequest, error) {
-	pullRequests := []*github.PullRequest{}
-
-	pageOpts := github.ListOptions{PerPage: 100}
-	opt := &github.SearchOptions{Sort: "created", Order: "asc", ListOptions: pageOpts}
-
-	for {
-
-		var searchResult *github.IssuesSearchResult
-		var resp *github.Response
-		searchErr := retry.Do(
-			func() error {
-				var err error
-				searchResult, resp, err = gc.Client.Search.Issues(gc.ctx, query, opt)
-				return checkIfRecoverable(err)
-			},
-			defaultRetryOptions...,
-		)
-
-		if searchErr != nil {
-			return nil, searchErr
-		}
-
-		// Convert every issue into a pull request
-		for _, issue := range searchResult.Issues {
-			repoOwner, repoName := gc.getRepoNameFromURL(*issue.HTMLURL)
-			pullRequest, prErr := gc.GetPR(repoOwner, repoName, *issue.Number)
-			if prErr != nil {
-				return nil, prErr
-			}
-			pullRequests = append(pullRequests, pullRequest)
-		}
-
-		if resp.NextPage == 0 {
-			break
-		}
-		opt.Page = resp.NextPage
-	}
-
-	return pullRequests, nil
-}
-
-func (gc *GithubClient) getRepoNameFromURL(url string) (string, string) {
-	// https://github.com/octocat/Hello-World/pull/1347
-	url = strings.ReplaceAll(url, "https://github.com/", "")
-	pieces := strings.Split(url, "/")
-	return pieces[0], pieces[1]
-}
-
-func (gc *GithubClient) GetPR(owner, repo string, number int) (*github.PullRequest, error) {
-	var pullRequest *github.PullRequest
-	searchErr := retry.Do(
-		func() error {
-			var err error
-			pullRequest, _, err = gc.Client.PullRequests.Get(gc.ctx, owner, repo, number)
-			return checkIfRecoverable(err)
-		},
-		defaultRetryOptions...,
-	)
-
-	return pullRequest, searchErr
-}
-
-func removeDuplicateStr(strSlice []string) []string {
-	allKeys := make(map[string]bool)
-	list := []string{}
-	for _, item := range strSlice {
-		if _, value := allKeys[item]; !value {
-			allKeys[item] = true
-			list = append(list, item)
-		}
-	}
-	return list
 }

--- a/pkg/github/utils.go
+++ b/pkg/github/utils.go
@@ -1,0 +1,22 @@
+package github
+
+import "strings"
+
+func (gc *GithubClient) getRepoNameFromURL(url string) (string, string) {
+	// https://github.com/octocat/Hello-World/pull/1347
+	url = strings.ReplaceAll(url, "https://github.com/", "")
+	pieces := strings.Split(url, "/")
+	return pieces[0], pieces[1]
+}
+
+func removeDuplicateStr(strSlice []string) []string {
+	allKeys := make(map[string]bool)
+	list := []string{}
+	for _, item := range strSlice {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}


### PR DESCRIPTION
# What

* Refactor GitHub code a little (splitting up files, abstracting common stanzas to functions)
* Get all PR data for the `list` command in parallel
* Add sensible buffer sizes to channels in the find-and-replace function

# Why

The persona assumption is that we're going to be running migrations on thousands of repos, which means thousands of PRs. Getting the list of GitHub issues returned from the search API and then sequentially turning them into PRs by fetching the PR data was pretty slow, especially at the 100+ range. So this fetches that data in parallel.

The main concern with this method is Github's "secondary rate limit" which intends to rate limit resource consumption in a short period, but our retry functions make an operation like this tolerant to the limits so it works out in the end.

I also changed the buffers for find-and-replace `chan`s, because I always forget that a channel is made blocking by default, unless you specify a buffer. 