### PR TITLE
Add a wait group to PR data workers

### DIFF
--- a/pkg/actions/replace.go
+++ b/pkg/actions/replace.go
@@ -61,7 +61,8 @@ func (r *Replace) Run(log *logrus.Entry) error {
 
 	if len(errChan) != 0 {
 		finalError := fmt.Errorf("")
-		for i := 0; i < len(errChan); i++ {
+		totalErrs := len(errChan)
+		for i := 0; i < totalErrs; i++ {
 			fileErr := <-errChan
 			finalError = errors.Join(finalError, fileErr)
 		}

--- a/pkg/core/clone.go
+++ b/pkg/core/clone.go
@@ -23,10 +23,13 @@ func (b *Banshee) Clone() error {
 		return cacheErr
 	}
 
+	b.log.Info("Fetching list of repos to clone")
 	org, repos, optionsErr := b.migrationOptions()
 	if optionsErr != nil {
 		return optionsErr
 	}
+
+	b.log.Info("Cloning ", len(repos), " repos")
 
 	for _, repo := range repos {
 		_, _, _, cloneErr := b.cloneRepo(b.log, org, repo)

--- a/pkg/core/list.go
+++ b/pkg/core/list.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	header = "state\tmergeable_state\thtml_url"
+	header = "state\tmergeable_state\thtml_url\treviewer_teams"
 )
 
 // Perform a migration
@@ -46,7 +46,11 @@ func (b *Banshee) List(state string, format string) error {
 				state = "merged"
 			}
 
-			line := strings.Join([]string{state, *pr.MergeableState, *pr.HTMLURL}, "\t")
+			teams := []string{}
+			for _, team := range pr.RequestedTeams {
+				teams = append(teams, *team.Name)
+			}
+			line := strings.Join([]string{state, *pr.MergeableState, *pr.HTMLURL, strings.Join(teams, ",")}, "\t")
 			fmt.Fprintln(w, line)
 		}
 		w.Flush()

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -84,6 +84,11 @@ func (b *Banshee) migrationOptions() (string, []string, error) {
 		}
 	}
 
+	if b.MigrationConfig.AllReposInOrg {
+		allRepos, allReposErr := b.GithubClient.GetAllRepos(org)
+		return org, allRepos, allReposErr
+	}
+
 	return org, []string{}, nil
 }
 

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -8,7 +8,7 @@ import (
 
 func (gc *GithubClient) GetAllRepos(owner string) ([]string, error) {
 	repos := []string{}
-	opt := &github.RepositoryListOptions{Type: "owner", Sort: "created", Direction: "asc"}
+	opt := &github.RepositoryListByOrgOptions{Type: "all", Sort: "created", Direction: "asc"}
 
 	for {
 
@@ -17,7 +17,7 @@ func (gc *GithubClient) GetAllRepos(owner string) ([]string, error) {
 		searchErr := retry.Do(
 			func() error {
 				var err error
-				searchResult, resp, err = gc.Client.Repositories.List(gc.ctx, owner, opt)
+				searchResult, resp, err = gc.Client.Repositories.ListByOrg(gc.ctx, owner, opt)
 				return checkIfRecoverable(err)
 			},
 			defaultRetryOptions...,


### PR DESCRIPTION
# What

* Adds a wait group to PR data workers
* Fixes the all_repos option

# Why

After adding #14, there's an issue with a low number of PR results where the workers fetch the data _after_ we start processing the results. To combat this, we've added a wait group to ensure that all the workers have returned before we start processing any results or errors.

While investigating this, I also noticed if you chose to use all repos, it would return an empty slice. Turns out there's a difference between listing all repositories for a user, and listing all repositories for an organisation. So that's been corrected now.