### PR TITLE
Do a hard reset before pulling any changes

### DIFF
--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -77,6 +77,13 @@ func (gc *GithubClient) Pull(branch string, gitRepo *git.Repository) error {
 		return wtErr
 	}
 
+	gc.log.Debug("Resetting ", plumbing.NewBranchReferenceName(branch), " and clearing any unstaged changes")
+	// Do a hard reset before pulling to ensure we start from a clean stage
+	resetErr := wt.Reset(&git.ResetOptions{Mode: git.HardReset})
+	if resetErr != nil {
+		return resetErr
+	}
+
 	gc.log.Debug("Pulling ", plumbing.NewBranchReferenceName(branch))
 	pullErr := wt.Pull(&git.PullOptions{
 		Progress:     gc.Writer,


### PR DESCRIPTION
# What

* Perform a hard reset before attempting to pull git changes

# Why

Noticed an issue where a repo could end up with "unstaged changes" that would prevent the pull (even with a force), so it feels like a case we should explicitly manage to ensure things run smoothly.