### PR TITLE
Refresh auth token for github app

### DIFF
--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -13,6 +13,16 @@ import (
 const defaultRemote = "origin"
 
 func (gc *GithubClient) auth() *gitHttp.BasicAuth {
+	if gc.tokenRefreshItr != nil {
+		accessToken, tokenRefreshErr := gc.tokenRefreshItr.Token(gc.ctx)
+		if tokenRefreshErr != nil {
+			gc.log.Error(tokenRefreshErr)
+		} else {
+			// Only update the access token if refreshing was succesful
+			gc.accessToken = accessToken
+		}
+	}
+
 	return &gitHttp.BasicAuth{
 		Username: "placeholderUsername", // anything except an empty string
 		Password: gc.accessToken,

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -18,7 +18,7 @@ func (gc *GithubClient) auth() *gitHttp.BasicAuth {
 		if tokenRefreshErr != nil {
 			gc.log.Error(tokenRefreshErr)
 		} else {
-			// Only update the access token if refreshing was succesful
+			// Only update the access token if refreshing was successful
 			gc.accessToken = accessToken
 		}
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -19,10 +19,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type RefreshTokenItr interface {
-	Token(ctx context.Context) (string, error)
-}
-
 type GithubClient struct {
 	Client       *github.Client
 	Writer       sideband.Progress


### PR DESCRIPTION
# What

* Refresh the access token for an app

# Why

If you're running operations on thousands of repos, it's gonna take a while, and the token only lasts for a short period of time. To get around this, we can use the built-in token refresh function to get a new one.