### PR TITLE
Fix assigning reviewers

### DIFF
--- a/pkg/actions/replace.go
+++ b/pkg/actions/replace.go
@@ -94,8 +94,8 @@ func (r *Replace) removeBlacklistedDirectories(matches []string) []string {
 
 func (r *Replace) findAndReplaceWorker(log *logrus.Entry, files <-chan string, errors chan<- error) {
 	for file := range files {
-		content, _ := os.ReadFile(file)
-		if !strings.Contains(string(content), r.OldString) {
+		content, readErr := os.ReadFile(file)
+		if !strings.Contains(string(content), r.OldString) || readErr != nil {
 			continue
 		}
 

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -48,6 +48,8 @@ func (b *Banshee) Migrate() error {
 		if repoErr != nil {
 			return repoErr
 		}
+
+		b.log.Println("")
 	}
 	return nil
 }
@@ -82,8 +84,6 @@ func (b *Banshee) migrationOptions() (string, []string, error) {
 		if repos, searchQueryErr := b.GithubClient.GetMatchingRepos(query); searchQueryErr != nil {
 			return org, b.saveRepos(repos), searchQueryErr
 		}
-
-		b.log.Println("")
 	}
 
 	if b.MigrationConfig.AllReposInOrg {

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -82,6 +82,8 @@ func (b *Banshee) migrationOptions() (string, []string, error) {
 		if repos, searchQueryErr := b.GithubClient.GetMatchingRepos(query); searchQueryErr != nil {
 			return org, b.saveRepos(repos), searchQueryErr
 		}
+
+		b.log.Println("")
 	}
 
 	if b.MigrationConfig.AllReposInOrg {
@@ -163,7 +165,9 @@ func (b *Banshee) handleRepo(log *logrus.Entry, org, repo string) (string, error
 		}
 	}
 
-	log.Info("PR for ", repo, ": ", htmlURL)
+	if htmlURL != "" {
+		log.Info("PR for ", repo, ": \033[32m", htmlURL, "\033[0m")
+	}
 	return htmlURL, nil
 }
 

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -123,9 +123,9 @@ func (gc *GithubClient) Push(branch string, gitRepo *git.Repository) error {
 
 	pushErr := gitRepo.Push(
 		&git.PushOptions{
-			Progress:   gc.Writer,
 			RemoteName: "origin",
 			Auth:       gc.auth(),
+			// Force:      true,
 		},
 	)
 


### PR DESCRIPTION
# What

* Fix reviewer assigning
* For find and replace, ignore any files that can't be read (e.g. symlinks)
* Don't show git push output, it's nearly always a prompt to create a pull request

# Why

I didn't have the right conditional for the reviewer assigning, and it default to assigning an owner to reviewer PRs that already had owners.