### PR TITLE
Moving b.SaveRepos to a different line to allow the function to execute

### DIFF
--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -259,7 +259,6 @@ func (b *Banshee) cloneRepo(log *logrus.Entry, org, repo string) (string, *git.R
 		dir, mkDirErr = os.MkdirTemp(os.TempDir(), strings.ReplaceAll(repo, "/", "-"))
 	}
 	if mkDirErr != nil {
-		print(":()")
 		return "", nil, "", mkDirErr
 	}
 

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -33,7 +33,6 @@ func (b *Banshee) Migrate() error {
 	}
 
 	if b.Progress != nil {
-		// This call wipes out a list of supplied repos as The non migrated repos hasn't been instantiated
 		repos = b.Progress.GetReposNotMigrated()
 		if (b.GlobalConfig.Options.SaveProgress.Batch) > 0 {
 			repos = repos[:b.GlobalConfig.Options.SaveProgress.Batch]


### PR DESCRIPTION
# What
moving b.saveRepos out of the return line. For some reason that was causing the function to never execute. Added DebugF line to allow future testing

# Why
After running into an issue where a list of repos
was not returning any repos during clone
or migrate I determined (with the debug lines)
the saveRepos function was not executing.
Splitting the line seems to have fixed it.

I have 0 idea why this is happening and my golang google fu was not helping me find the efficiency flags that may avoid execution of it. It could be a preoptimization due to line 36 overwriting the repos var making the compiler _think_ the data isn't used but not knowing the side effect of the earlier function is causing state changes. 