### PR TITLE
Add a small wait before checking if working tree is dirty

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -27,6 +27,8 @@ publish:
 
 # Run a migration using the test config migration.test.yaml
 example_migration: _check_test_conf_exists
+    rm -r repos.cache/*
+    mkdir -p repos.cache/_progress
     go run cmd/banshee/main.go migrate examples/migration_config/migration.test.yaml \
         --config examples/global_config/config.test.yaml
 

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -142,6 +142,8 @@ func (b *Banshee) handleRepo(log *logrus.Entry, org, repo string) (string, error
 			return "", actionErr
 		}
 
+		// Wait for half a second to let the git working tree catch up with changes
+		time.Sleep(500 * time.Millisecond)
 		tree, _ := gitRepo.Worktree()
 		state, _ := tree.Status()
 		// check if git dirty


### PR DESCRIPTION
# What

* Add a 500ms wait after running an action

# Why

We were checking the working tree for state change too quickly after running an action, and it was giving the illusion that you needed at least two actions in a migration. I'm unsure why adding more actions got around this issue, but adding the wait seems to consistently fix it.

Fixes #80 