### PR TITLE
Create progress dir on startup

### DIFF
--- a/pkg/core/options.go
+++ b/pkg/core/options.go
@@ -7,5 +7,11 @@ func (b *Banshee) CreateCacheRepoIfEnabled() error {
 		}
 	}
 
+	if b.GlobalConfig.Options.SaveProgress.Enabled {
+		if cacheErr := b.createCacheRepo(b.log, b.GlobalConfig.Options.SaveProgress.Directory); cacheErr != nil {
+			return cacheErr
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
# What

* Create progress dir if enabled 

# Why

We were already creating the cache directory if it was enabled, so it was an easy add to also create the progress file directory as well.