### PR TITLE
Add environment variables to the run_command action

### DIFF
--- a/cmd/banshee/main.go
+++ b/cmd/banshee/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/lipgloss"
@@ -93,6 +94,11 @@ func parseConfig[C configs.Configs](conf C, file string, envKey string) C {
 func createBanshee(globalConfig configs.GlobalConfig, migrationConfigPath string) *core.Banshee {
 	var migrationConfig configs.MigrationConfig
 	migrationConfig = parseConfig(migrationConfig, migrationConfigPath, "APP")
+
+	absPath, absErr := filepath.Abs(migrationConfigPath)
+	handleErr(absErr)
+
+	globalConfig.MigrationDir = path.Dir(absPath)
 	banshee, initErr := core.NewBanshee(globalConfig, migrationConfig)
 	handleErr(initErr)
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -51,6 +51,13 @@ Any field with a default of `-` is a required field.
 | ------: | ----------------------------------------------------------------------------------------------- | ------- |
 | command | The command to be run. This command is passed to a bash shell, so it should be bash compatible. | –       |
 
+
+The environment from the execution environment is forwarded to the run command. There are also some added helper variables:
+
+|           Var | Description                               |
+| ------------: | ----------------------------------------- |
+| MIGRATION_DIR | The directory of the migration YAML file. |
+
 ```yaml
 - action: run_command
   description: "Example command run"

--- a/examples/migration_config/migration.yaml
+++ b/examples/migration_config/migration.yaml
@@ -23,7 +23,7 @@ actions:
   - action: run_command
     description: "Example command run"
     input: 
-      command: "echo 'Test' > test.txt"
+      command: "echo 'Test' > ${MIGRATION_DIR}/test.txt"
   - action: yaml
     description: "Change a YAML file"
     input: 

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -23,7 +23,7 @@ func RunAction(log *logrus.Entry, globalConfig *configs.GlobalConfig, actionID s
 	case "replace":
 		action = NewReplaceAction(dir, description, input, globalConfig.Options.IgnoreDirectories)
 	case "run_command":
-		action = NewRunCommandAction(dir, description, input)
+		action = NewRunCommandAction(dir, description, input, globalConfig)
 	case "yaml":
 		action = NewYAMLAction(dir, description, input)
 	default:

--- a/pkg/actions/run_command.go
+++ b/pkg/actions/run_command.go
@@ -3,22 +3,26 @@ package actions
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/sirupsen/logrus"
+	"github.com/thejokersthief/banshee/pkg/configs"
 )
 
 const defaultShell = "bash"
 
 type RunCommand struct {
-	BaseDir string
-	Command string
+	BaseDir      string
+	Command      string
+	GlobalConfig *configs.GlobalConfig
 }
 
-func NewRunCommandAction(dir string, description string, input map[string]string) *RunCommand {
+func NewRunCommandAction(dir string, description string, input map[string]string, globalConfig *configs.GlobalConfig) *RunCommand {
 	return &RunCommand{
-		BaseDir: dir,
-		Command: input["command"],
+		BaseDir:      dir,
+		Command:      input["command"],
+		GlobalConfig: globalConfig,
 	}
 }
 
@@ -28,6 +32,10 @@ func (r *RunCommand) Run(log *logrus.Entry) error {
 	cmd := exec.Command(defaultShell, "-c", r.Command)
 	cmd.Stdout = log.WriterLevel(logrus.DebugLevel)
 	cmd.Stderr = log.WriterLevel(logrus.ErrorLevel)
+	cmd.Env = append(
+		os.Environ(),
+		"MIGRATION_DIR="+r.GlobalConfig.MigrationDir,
+	)
 	cmd.Dir = r.BaseDir
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed running `%s`: %w", r.Command, err)

--- a/pkg/actions/run_command_test.go
+++ b/pkg/actions/run_command_test.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/thejokersthief/banshee/pkg/configs"
 )
 
 func TestRunCommand_Run(t *testing.T) {
 	// Create a new RunCommand instance
 	rc := &RunCommand{
-		Command: "echo 'Hello, World!'",
-		BaseDir: "./",
+		Command:      "echo 'Hello, World!'",
+		BaseDir:      "./",
+		GlobalConfig: &configs.GlobalConfig{MigrationDir: "/tmp"},
 	}
 
 	// Create a buffer to capture the command output

--- a/pkg/configs/global.go
+++ b/pkg/configs/global.go
@@ -11,6 +11,9 @@ type GlobalConfig struct {
 	Options OptionsConfig `fig:"options"`
 
 	Defaults DefaultsConfig `fig:"defaults"`
+
+	// Computed fields
+	MigrationDir string
 }
 
 type GithubConfig struct {


### PR DESCRIPTION
# What

* Forward the environment from the exec environment to the `run_command` action
* Added a `MIGRATION_DIR` env variable for use in the `run_command` action

# Why

Running scripts from the migration directory is really useful, so the MIGRATION_DIR variable gives us an easy way to reference the aboslute path of that directory.
