### PR TITLE
feat: worktree support for cached repos

### DIFF
--- a/.circleci/_config.jsonnet
+++ b/.circleci/_config.jsonnet
@@ -10,7 +10,7 @@ local tag_filter = workflows.filter_tags(only=['/v.*/']) + workflows.filter_bran
 local branches_filter = workflows.filter_branches(only=['/.*/']) + workflows.filter_tags(ignore=['/.*/']);
 
 local homedir = '/home/circleci/banshee';
-local gover = '1.26';
+local gover = '1.25';
 
 
 pipeline.new(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thejokersthief/banshee/v2
 
-go 1.26.0
+go 1.25.0
 
 require (
 	github.com/alecthomas/kong v1.11.0

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -16,6 +16,9 @@ import (
 // Defined as an interface to allow injection of test doubles.
 type githubClient interface {
 	ShallowClone(org, repoName, dir, migrationBranchName string) (string, error)
+	ShallowCloneWorktree(org, repoName, cacheDir, worktreeDir, migrationBranchName string) (string, error)
+	GitWorktreeRemove(repoDir, worktreeDir string) error
+	GitWorktreePrune(repoDir string) error
 	GetDefaultBranch(owner, repo string) (string, error)
 	GitIsClean(dir string) (bool, error)
 	GitAddAll(dir string) error

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/go-github/v63/github"
@@ -177,6 +178,12 @@ func (b *Banshee) getCacheRepoPath(org, repo string) string {
 	return fmt.Sprintf("%s/%s-%s", b.GlobalConfig.Options.CacheRepos.Directory, org, repo)
 }
 
+func (b *Banshee) getWorktreePath(org, repo string) string {
+	safeBranch := strings.ReplaceAll(b.MigrationConfig.BranchName, "/", "-")
+	return fmt.Sprintf("%s/%s-%s-wt/%s",
+		b.GlobalConfig.Options.CacheRepos.Directory, org, repo, safeBranch)
+}
+
 // Handle the migration for a repo
 func (b *Banshee) handleRepo(log *logrus.Entry, org, repo string) (string, error) {
 	repoNameOnly := strings.TrimPrefix(repo, org+"/")
@@ -187,8 +194,15 @@ func (b *Banshee) handleRepo(log *logrus.Entry, org, repo string) (string, error
 		return "", cloneErr
 	}
 
-	if !b.GlobalConfig.Options.CacheRepos.Enabled {
-		// If we're not caching repos, delete the repo directory when this function returns
+	if b.GlobalConfig.Options.CacheRepos.Enabled {
+		cacheDir := b.getCacheRepoPath(org, repoNameOnly)
+		defer func() {
+			if rmErr := b.GithubClient.GitWorktreeRemove(cacheDir, dir); rmErr != nil {
+				log.Warnf("worktree cleanup failed for %s: %v", dir, rmErr)
+				_ = os.RemoveAll(dir) // fallback: just delete the directory
+			}
+		}()
+	} else {
 		defer func() { _ = os.RemoveAll(dir) }()
 	}
 
@@ -294,23 +308,17 @@ func (b *Banshee) formatChangelog(pr *github.PullRequest, changelog []string) (s
 	return prBody, nil
 }
 
-// cloneRepo clones a repo and returns its dir and default branch.
+// cloneRepo clones a repo and returns its working dir and default branch.
+// When cache_repos is enabled, a worktree is created so the cached clone stays
+// on the default branch and each migration gets an isolated directory.
 func (b *Banshee) cloneRepo(log *logrus.Entry, org, repo string) (string, string, error) {
 	repoNameOnly := strings.TrimPrefix(repo, org+"/")
 
-	var dir string
-	var mkDirErr error
-	var cacheCreated bool
 	if b.GlobalConfig.Options.CacheRepos.Enabled {
-		dir = b.getCacheRepoPath(org, repoNameOnly)
-		// Track whether we're creating a new dir so we can clean up on failure.
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			cacheCreated = true
-		}
-		mkDirErr = b.createCacheRepo(log, dir)
-	} else {
-		dir, mkDirErr = os.MkdirTemp(os.TempDir(), strings.ReplaceAll(repo, "/", "-"))
+		return b.cloneRepoWorktree(log, org, repoNameOnly)
 	}
+
+	dir, mkDirErr := os.MkdirTemp(os.TempDir(), strings.ReplaceAll(repo, "/", "-"))
 	if mkDirErr != nil {
 		return "", "", mkDirErr
 	}
@@ -319,12 +327,44 @@ func (b *Banshee) cloneRepo(log *logrus.Entry, org, repo string) (string, string
 
 	defaultBranch, cloneErr := b.GithubClient.ShallowClone(org, repoNameOnly, dir, b.MigrationConfig.BranchName)
 	if cloneErr != nil {
-		// CORE-I1: clean up a newly created cache dir on clone failure.
-		if b.GlobalConfig.Options.CacheRepos.Enabled && cacheCreated {
-			_ = os.RemoveAll(dir)
-		}
 		return "", "", fmt.Errorf("clone error: %w", cloneErr)
 	}
 
 	return dir, defaultBranch, nil
+}
+
+// cloneRepoWorktree handles the cached-repo + worktree path.
+func (b *Banshee) cloneRepoWorktree(log *logrus.Entry, org, repoNameOnly string) (string, string, error) {
+	cacheDir := b.getCacheRepoPath(org, repoNameOnly)
+	worktreeDir := b.getWorktreePath(org, repoNameOnly)
+
+	// Clean up any leftover worktree from an interrupted run.
+	if _, err := os.Stat(worktreeDir); err == nil {
+		log.Warn("Removing leftover worktree directory ", worktreeDir)
+		_ = os.RemoveAll(worktreeDir)
+		// Prune stale git worktree metadata if the cache repo exists.
+		if _, statErr := os.Stat(cacheDir + "/.git"); statErr == nil {
+			_ = b.GithubClient.GitWorktreePrune(cacheDir)
+		}
+	}
+
+	// Ensure parent directories exist for both cache and worktree.
+	if err := b.createCacheRepo(log, cacheDir); err != nil {
+		return "", "", err
+	}
+	worktreeParent := filepath.Dir(worktreeDir)
+	if err := b.createCacheRepo(log, worktreeParent); err != nil {
+		return "", "", err
+	}
+
+	log.Info("Using cache ", cacheDir, ", worktree ", worktreeDir)
+
+	defaultBranch, cloneErr := b.GithubClient.ShallowCloneWorktree(
+		org, repoNameOnly, cacheDir, worktreeDir, b.MigrationConfig.BranchName,
+	)
+	if cloneErr != nil {
+		return "", "", fmt.Errorf("clone error: %w", cloneErr)
+	}
+
+	return worktreeDir, defaultBranch, nil
 }

--- a/pkg/core/migrate_test.go
+++ b/pkg/core/migrate_test.go
@@ -90,6 +90,27 @@ func (f *fakeGithubClient) ShallowClone(org, repoName, dir, migrationBranchName 
 	return f.defaultBranch, f.git.Checkout(dir, migrationBranchName, true)
 }
 
+func (f *fakeGithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDir, migrationBranchName string) (string, error) {
+	if _, err := os.Stat(cacheDir + "/.git"); os.IsNotExist(err) {
+		if err := f.git.Clone(f.bareRepoURL, cacheDir, f.defaultBranch, 0); err != nil {
+			return "", err
+		}
+	} else {
+		if err := f.git.Checkout(cacheDir, f.defaultBranch, false); err != nil {
+			return "", err
+		}
+	}
+	if err := f.git.WorktreeAdd(cacheDir, worktreeDir, migrationBranchName, true); err != nil {
+		return "", err
+	}
+	return f.defaultBranch, nil
+}
+func (f *fakeGithubClient) GitWorktreeRemove(repoDir, worktreeDir string) error {
+	return f.git.WorktreeRemove(repoDir, worktreeDir)
+}
+func (f *fakeGithubClient) GitWorktreePrune(repoDir string) error {
+	return f.git.WorktreePrune(repoDir)
+}
 func (f *fakeGithubClient) GetDefaultBranch(_, _ string) (string, error) {
 	return f.defaultBranch, nil
 }
@@ -183,6 +204,83 @@ func TestHandleRepo(t *testing.T) {
 	run("git", "clone", "--branch", "migration-branch", bareDir, verifyDir)
 	assert.FileExists(t, filepath.Join(verifyDir, "migrated.txt"),
 		"migrated.txt should have been committed and pushed to the migration branch")
+}
+
+// TestHandleRepoWithWorktree verifies the worktree-based cache flow:
+// push happens, worktree is cleaned up, and the cache dir stays on the default branch.
+func TestHandleRepoWithWorktree(t *testing.T) {
+	bareDir, branch := setupBareRepo(t)
+	run := func(name string, args ...string) {
+		t.Helper()
+		out, err := exec.Command(name, args...).CombinedOutput()
+		require.NoError(t, err, "%s %v: %s", name, args, out)
+	}
+
+	prBodyFile := filepath.Join(t.TempDir(), "pr-body.md")
+	require.NoError(t, os.WriteFile(prBodyFile, []byte("<!-- changelog -->"), 0644))
+
+	cacheDir := t.TempDir()
+
+	globalConf := configs.GlobalConfig{
+		Options: configs.OptionsConfig{
+			LogLevel: "info",
+			CacheRepos: configs.CacheReposConfig{
+				Enabled:   true,
+				Directory: cacheDir,
+			},
+		},
+		Github: configs.GithubConfig{Token: "testtoken"},
+		Defaults: configs.DefaultsConfig{
+			Organisation: "testorg",
+			GitName:      "Test User",
+			GitEmail:     "test@example.com",
+		},
+	}
+	migConf := configs.MigrationConfig{
+		BranchName:  "migration-branch",
+		PRBodyFile:  prBodyFile,
+		PRTitle:     "Test worktree migration",
+		ListOfRepos: []string{"testrepo"},
+		Actions: []configs.Action{
+			{
+				Action:      "run_command",
+				Description: "Add a file",
+				Input:       map[string]string{"command": "touch migrated.txt"},
+			},
+		},
+	}
+
+	b, err := NewBanshee(globalConf, migConf)
+	require.NoError(t, err)
+
+	g := gitcli.NewExecGit(false, logrus.NewEntry(logrus.New()))
+	b.GithubClient = &fakeGithubClient{
+		git:           g,
+		bareRepoURL:   bareDir,
+		defaultBranch: branch,
+		createdPRURL:  "https://github.com/testorg/testrepo/pull/2",
+	}
+
+	htmlURL, err := b.handleRepo(b.log.WithField("repo", "testorg/testrepo"), "testorg", "testorg/testrepo")
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/testorg/testrepo/pull/2", htmlURL)
+	assert.Equal(t, 1, b.GithubClient.(*fakeGithubClient).pushCallCount)
+
+	// Verify worktree directory was cleaned up.
+	worktreeDir := b.getWorktreePath("testorg", "testrepo")
+	assert.NoDirExists(t, worktreeDir, "worktree should be cleaned up after handleRepo")
+
+	// Verify cache dir still exists with .git on the default branch.
+	cachePath := b.getCacheRepoPath("testorg", "testrepo")
+	assert.DirExists(t, filepath.Join(cachePath, ".git"), "cache dir should still have .git")
+	out, err := exec.Command("git", "-C", cachePath, "symbolic-ref", "--short", "HEAD").Output()
+	require.NoError(t, err)
+	assert.Equal(t, branch, strings.TrimSpace(string(out)), "cache should remain on default branch")
+
+	// Verify the commit was pushed to the bare repo.
+	verifyDir := filepath.Join(t.TempDir(), "verify")
+	run("git", "clone", "--branch", "migration-branch", bareDir, verifyDir)
+	assert.FileExists(t, filepath.Join(verifyDir, "migrated.txt"))
 }
 
 // TestHandleRepoNoChanges verifies that handleRepo returns an empty URL (no PR)

--- a/pkg/gitcli/exec.go
+++ b/pkg/gitcli/exec.go
@@ -70,6 +70,8 @@ func parseGitError(stderr string) error {
 		return ErrReferenceNotFound
 	case strings.Contains(lower, "couldn't find remote ref"):
 		return ErrRemoteRefNotFound
+	case strings.Contains(lower, "already checked out") || strings.Contains(lower, "already used by worktree"):
+		return ErrWorktreeAlreadyExists
 	default:
 		msg := stderr
 		if msg == "" {
@@ -178,5 +180,39 @@ func (g *ExecGit) Commit(dir, message, authorName, authorEmail string) error {
 		"-c", "user.email="+authorEmail,
 		"commit", "--author", author, "-m", message,
 	)
+	return err
+}
+
+// WorktreeAdd creates a git worktree at worktreeDir for the given branch.
+// When create=true, a new branch is created (-b). If the worktree already
+// exists (stale from an interrupted run), it is removed and retried.
+func (g *ExecGit) WorktreeAdd(repoDir, worktreeDir, branch string, create bool) error {
+	args := []string{"-C", repoDir, "worktree", "add"}
+	if create {
+		args = append(args, "-b", branch, worktreeDir)
+	} else {
+		args = append(args, worktreeDir, branch)
+	}
+
+	_, err := g.run("", args...)
+	if errors.Is(err, ErrWorktreeAlreadyExists) {
+		// Stale worktree from a previous interrupted run — prune stale references and retry.
+		if _, pruneErr := g.run("", "-C", repoDir, "worktree", "prune"); pruneErr != nil {
+			return fmt.Errorf("pruning stale worktrees before retry: %w", pruneErr)
+		}
+		_, err = g.run("", args...)
+	}
+	return err
+}
+
+// WorktreeRemove forcefully removes a git worktree.
+func (g *ExecGit) WorktreeRemove(repoDir, worktreeDir string) error {
+	_, err := g.run("", "-C", repoDir, "worktree", "remove", "--force", worktreeDir)
+	return err
+}
+
+// WorktreePrune removes stale worktree metadata from the repo.
+func (g *ExecGit) WorktreePrune(repoDir string) error {
+	_, err := g.run("", "-C", repoDir, "worktree", "prune")
 	return err
 }

--- a/pkg/gitcli/exec_test.go
+++ b/pkg/gitcli/exec_test.go
@@ -325,6 +325,74 @@ func TestCommit(t *testing.T) {
 	assert.Equal(t, "alice@example.com", authorEmail)
 }
 
+// ── WorktreeAdd / WorktreeRemove ──────────────────────────────────────────────
+
+func TestWorktreeAddAndRemove(t *testing.T) {
+	bareDir, branch := initBareWithContent(t)
+
+	// Clone the bare repo to use as the main repo dir.
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, newGit(t).Clone(bareDir, repoDir, branch, 0))
+
+	g := newGit(t)
+
+	// Add a worktree with a new branch.
+	wtDir := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, g.WorktreeAdd(repoDir, wtDir, "wt-branch", true))
+
+	// Verify the worktree exists and is on the expected branch.
+	assert.DirExists(t, wtDir)
+	assert.Equal(t, "wt-branch", headBranch(t, wtDir))
+
+	// Remove the worktree.
+	require.NoError(t, g.WorktreeRemove(repoDir, wtDir))
+	assert.NoDirExists(t, wtDir)
+}
+
+func TestWorktreeAddExistingBranch(t *testing.T) {
+	bareDir, branch := initBareWithContent(t)
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, newGit(t).Clone(bareDir, repoDir, branch, 0))
+
+	g := newGit(t)
+
+	// Create the branch first, then add worktree without -b.
+	runCmd(t, "git", "-C", repoDir, "branch", "existing-wt-branch")
+
+	wtDir := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, g.WorktreeAdd(repoDir, wtDir, "existing-wt-branch", false))
+
+	assert.DirExists(t, wtDir)
+	assert.Equal(t, "existing-wt-branch", headBranch(t, wtDir))
+
+	require.NoError(t, g.WorktreeRemove(repoDir, wtDir))
+}
+
+func TestWorktreeAddStaleRecovery(t *testing.T) {
+	bareDir, branch := initBareWithContent(t)
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, newGit(t).Clone(bareDir, repoDir, branch, 0))
+
+	g := newGit(t)
+
+	// Create an initial worktree, then delete the directory (simulating interrupted run).
+	wtDir := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, g.WorktreeAdd(repoDir, wtDir, "stale-branch", true))
+	require.NoError(t, os.RemoveAll(wtDir))
+
+	// Adding a new worktree for the same branch should recover via prune+retry.
+	wtDir2 := filepath.Join(t.TempDir(), "worktree2")
+	require.NoError(t, g.WorktreeAdd(repoDir, wtDir2, "stale-branch", false))
+
+	assert.DirExists(t, wtDir2)
+	assert.Equal(t, "stale-branch", headBranch(t, wtDir2))
+
+	// Cleanup.
+	require.NoError(t, g.WorktreeRemove(repoDir, wtDir2))
+}
+
 // ── parseGitError ─────────────────────────────────────────────────────────────
 
 func TestParseGitError(t *testing.T) {
@@ -373,6 +441,11 @@ func TestParseGitError(t *testing.T) {
 			name:    "couldn't find remote ref (mixed case)",
 			stderr:  "Fatal: Couldn't Find Remote Ref feature",
 			wantErr: ErrRemoteRefNotFound,
+		},
+		{
+			name:    "worktree already checked out",
+			stderr:  "fatal: 'stale-branch' is already checked out at '/tmp/worktree'",
+			wantErr: ErrWorktreeAlreadyExists,
 		},
 		{
 			name:     "unknown error returns GitError",

--- a/pkg/gitcli/git.go
+++ b/pkg/gitcli/git.go
@@ -3,10 +3,11 @@ package gitcli
 import "errors"
 
 var (
-	ErrBranchAlreadyExists = errors.New("git: branch already exists")
-	ErrAlreadyUpToDate     = errors.New("git: already up to date")
-	ErrReferenceNotFound   = errors.New("git: reference not found")
-	ErrRemoteRefNotFound   = errors.New("git: couldn't find remote ref")
+	ErrBranchAlreadyExists   = errors.New("git: branch already exists")
+	ErrAlreadyUpToDate       = errors.New("git: already up to date")
+	ErrReferenceNotFound     = errors.New("git: reference not found")
+	ErrRemoteRefNotFound     = errors.New("git: couldn't find remote ref")
+	ErrWorktreeAlreadyExists = errors.New("git: worktree already checked out")
 )
 
 type Git interface {
@@ -18,4 +19,7 @@ type Git interface {
 	IsClean(dir string) (bool, error)
 	AddAll(dir string) error
 	Commit(dir, message, authorName, authorEmail string) error
+	WorktreeAdd(repoDir, worktreeDir, branch string, create bool) error
+	WorktreeRemove(repoDir, worktreeDir string) error
+	WorktreePrune(repoDir string) error
 }

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -23,3 +23,13 @@ func (gc *GithubClient) GitAddAll(dir string) error {
 func (gc *GithubClient) GitCommit(dir, message, name, email string) error {
 	return gc.git.Commit(dir, message, name, email)
 }
+
+// GitWorktreeRemove removes a git worktree from the given repo directory.
+func (gc *GithubClient) GitWorktreeRemove(repoDir, worktreeDir string) error {
+	return gc.git.WorktreeRemove(repoDir, worktreeDir)
+}
+
+// GitWorktreePrune removes stale worktree metadata from the repo.
+func (gc *GithubClient) GitWorktreePrune(repoDir string) error {
+	return gc.git.WorktreePrune(repoDir)
+}

--- a/pkg/github/git_test.go
+++ b/pkg/github/git_test.go
@@ -12,14 +12,16 @@ import (
 // ── fakeGit ───────────────────────────────────────────────────────────────────
 
 type fakeGit struct {
-	cloneArgs   *cloneCall
-	checkoutArgs *checkoutCall
-	fetchArgs   *fetchCall
-	pullArgs    *pullCall
-	pushArgs    *pushCall
-	isCleanArgs *isCleanCall
-	addAllArgs  *addAllCall
-	commitArgs  *commitCall
+	cloneArgs         *cloneCall
+	checkoutArgs      *checkoutCall
+	fetchArgs         *fetchCall
+	pullArgs          *pullCall
+	pushArgs          *pushCall
+	isCleanArgs       *isCleanCall
+	addAllArgs        *addAllCall
+	commitArgs        *commitCall
+	worktreeAddArgs   *worktreeAddCall
+	worktreeRemoveArgs *worktreeRemoveCall
 
 	isCleanResult bool
 	err           error
@@ -32,7 +34,9 @@ type pullCall    struct{ dir, tokenURL, branch string }
 type pushCall    struct{ dir, tokenURL, branch string }
 type isCleanCall struct{ dir string }
 type addAllCall  struct{ dir string }
-type commitCall  struct{ dir, message, name, email string }
+type commitCall        struct{ dir, message, name, email string }
+type worktreeAddCall   struct{ repoDir, worktreeDir, branch string; create bool }
+type worktreeRemoveCall struct{ repoDir, worktreeDir string }
 
 func (f *fakeGit) Clone(tokenURL, dir, branch string, depth int) error {
 	f.cloneArgs = &cloneCall{tokenURL, dir, branch, depth}
@@ -64,6 +68,17 @@ func (f *fakeGit) AddAll(dir string) error {
 }
 func (f *fakeGit) Commit(dir, message, name, email string) error {
 	f.commitArgs = &commitCall{dir, message, name, email}
+	return f.err
+}
+func (f *fakeGit) WorktreeAdd(repoDir, worktreeDir, branch string, create bool) error {
+	f.worktreeAddArgs = &worktreeAddCall{repoDir, worktreeDir, branch, create}
+	return f.err
+}
+func (f *fakeGit) WorktreeRemove(repoDir, worktreeDir string) error {
+	f.worktreeRemoveArgs = &worktreeRemoveCall{repoDir, worktreeDir}
+	return f.err
+}
+func (f *fakeGit) WorktreePrune(_ string) error {
 	return f.err
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -154,6 +155,73 @@ func (gc *GithubClient) ShallowClone(org, repoName, dir, migrationBranchName str
 	}
 	if err := gc.git.Pull(dir, migURL, migrationBranchName); err != nil {
 		return "", err
+	}
+
+	return defaultBranch, nil
+}
+
+// ShallowCloneWorktree clones (or updates) the cached repo on the default branch,
+// then creates a git worktree for the migration branch. Returns the default branch name.
+func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDir, migrationBranchName string) (string, error) {
+	defaultBranch, err := gc.GetDefaultBranch(org, repoName)
+	if err != nil {
+		return "", err
+	}
+
+	tokenURL, err := gc.freshTokenURL(org, repoName)
+	if err != nil {
+		return "", err
+	}
+
+	// Clone or update the cache directory on the default branch.
+	if _, err := os.Stat(cacheDir + "/.git"); errors.Is(err, os.ErrNotExist) {
+		gc.log.Info("Cloning ", repoName, " [", defaultBranch, "] into cache...")
+		if err := gc.git.Clone(tokenURL, cacheDir, defaultBranch, 1); err != nil {
+			return "", err
+		}
+	} else {
+		gc.log.Info("Updating cache ", cacheDir, " [", defaultBranch, "]...")
+		if err := gc.git.Checkout(cacheDir, defaultBranch, false); err != nil {
+			return "", err
+		}
+		if err := gc.git.Pull(cacheDir, tokenURL, defaultBranch); err != nil {
+			return "", err
+		}
+	}
+
+	// Fetch the migration branch from remote (swallow "not found").
+	fetchURL, err := gc.freshTokenURL(org, repoName)
+	if err != nil {
+		return "", err
+	}
+	if err := gc.git.Fetch(cacheDir, fetchURL, migrationBranchName); err != nil {
+		return "", err
+	}
+
+	// Create the worktree — try existing branch first, then create new.
+	if firstErr := gc.git.WorktreeAdd(cacheDir, worktreeDir, migrationBranchName, false); firstErr != nil {
+		// Only fall back to creating a new branch if the branch doesn't exist locally.
+		var ge *gitcli.GitError
+		if !errors.As(firstErr, &ge) || !strings.Contains(ge.Stderr, "invalid reference") {
+			return "", fmt.Errorf("worktree add: %w", firstErr)
+		}
+		if createErr := gc.git.WorktreeAdd(cacheDir, worktreeDir, migrationBranchName, true); createErr != nil {
+			return "", fmt.Errorf("worktree add: %w", createErr)
+		}
+	}
+
+	// If the branch existed remotely, pull latest into the worktree.
+	pullURL, err := gc.freshTokenURL(org, repoName)
+	if err != nil {
+		return "", err
+	}
+	if pullErr := gc.git.Pull(worktreeDir, pullURL, migrationBranchName); pullErr != nil {
+		// ErrReferenceNotFound means the branch is new (local only) — safe to ignore.
+		if errors.Is(pullErr, gitcli.ErrReferenceNotFound) {
+			gc.log.Debug("Migration branch is new, skipping pull in worktree")
+		} else {
+			return "", pullErr
+		}
 	}
 
 	return defaultBranch, nil

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -160,6 +160,37 @@ func (gc *GithubClient) ShallowClone(org, repoName, dir, migrationBranchName str
 	return defaultBranch, nil
 }
 
+// ensureCacheClone clones the repo into dir (shallow, default branch) or updates
+// an existing clone by checking out the default branch and pulling.
+func (gc *GithubClient) ensureCacheClone(tokenURL, dir, repoName, defaultBranch string) error {
+	if _, err := os.Stat(dir + "/.git"); errors.Is(err, os.ErrNotExist) {
+		gc.log.Info("Cloning ", repoName, " [", defaultBranch, "] into cache...")
+		return gc.git.Clone(tokenURL, dir, defaultBranch, 1)
+	}
+	gc.log.Info("Updating cache ", dir, " [", defaultBranch, "]...")
+	if err := gc.git.Checkout(dir, defaultBranch, false); err != nil {
+		return err
+	}
+	return gc.git.Pull(dir, tokenURL, defaultBranch)
+}
+
+// addWorktreeForBranch creates a worktree, trying an existing branch first
+// and falling back to creating a new one if the reference doesn't exist.
+func (gc *GithubClient) addWorktreeForBranch(repoDir, worktreeDir, branch string) error {
+	firstErr := gc.git.WorktreeAdd(repoDir, worktreeDir, branch, false)
+	if firstErr == nil {
+		return nil
+	}
+	var ge *gitcli.GitError
+	if !errors.As(firstErr, &ge) || !strings.Contains(ge.Stderr, "invalid reference") {
+		return fmt.Errorf("worktree add: %w", firstErr)
+	}
+	if createErr := gc.git.WorktreeAdd(repoDir, worktreeDir, branch, true); createErr != nil {
+		return fmt.Errorf("worktree add: %w", createErr)
+	}
+	return nil
+}
+
 // ShallowCloneWorktree clones (or updates) the cached repo on the default branch,
 // then creates a git worktree for the migration branch. Returns the default branch name.
 func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDir, migrationBranchName string) (string, error) {
@@ -172,21 +203,8 @@ func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDi
 	if err != nil {
 		return "", err
 	}
-
-	// Clone or update the cache directory on the default branch.
-	if _, err := os.Stat(cacheDir + "/.git"); errors.Is(err, os.ErrNotExist) {
-		gc.log.Info("Cloning ", repoName, " [", defaultBranch, "] into cache...")
-		if err := gc.git.Clone(tokenURL, cacheDir, defaultBranch, 1); err != nil {
-			return "", err
-		}
-	} else {
-		gc.log.Info("Updating cache ", cacheDir, " [", defaultBranch, "]...")
-		if err := gc.git.Checkout(cacheDir, defaultBranch, false); err != nil {
-			return "", err
-		}
-		if err := gc.git.Pull(cacheDir, tokenURL, defaultBranch); err != nil {
-			return "", err
-		}
+	if err := gc.ensureCacheClone(tokenURL, cacheDir, repoName, defaultBranch); err != nil {
+		return "", err
 	}
 
 	// Fetch the migration branch from remote (swallow "not found").
@@ -198,16 +216,8 @@ func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDi
 		return "", err
 	}
 
-	// Create the worktree — try existing branch first, then create new.
-	if firstErr := gc.git.WorktreeAdd(cacheDir, worktreeDir, migrationBranchName, false); firstErr != nil {
-		// Only fall back to creating a new branch if the branch doesn't exist locally.
-		var ge *gitcli.GitError
-		if !errors.As(firstErr, &ge) || !strings.Contains(ge.Stderr, "invalid reference") {
-			return "", fmt.Errorf("worktree add: %w", firstErr)
-		}
-		if createErr := gc.git.WorktreeAdd(cacheDir, worktreeDir, migrationBranchName, true); createErr != nil {
-			return "", fmt.Errorf("worktree add: %w", createErr)
-		}
+	if err := gc.addWorktreeForBranch(cacheDir, worktreeDir, migrationBranchName); err != nil {
+		return "", err
 	}
 
 	// If the branch existed remotely, pull latest into the worktree.
@@ -217,11 +227,10 @@ func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDi
 	}
 	if pullErr := gc.git.Pull(worktreeDir, pullURL, migrationBranchName); pullErr != nil {
 		// ErrReferenceNotFound means the branch is new (local only) — safe to ignore.
-		if errors.Is(pullErr, gitcli.ErrReferenceNotFound) {
-			gc.log.Debug("Migration branch is new, skipping pull in worktree")
-		} else {
+		if !errors.Is(pullErr, gitcli.ErrReferenceNotFound) {
 			return "", pullErr
 		}
+		gc.log.Debug("Migration branch is new, skipping pull in worktree")
 	}
 
 	return defaultBranch, nil


### PR DESCRIPTION
## Summary

- When `cache_repos` is enabled, use git worktrees instead of checking out the migration branch directly in the cached clone
- The cached clone stays on the default branch while each migration gets an isolated worktree directory
- Enables concurrent migrations and safer recovery from interrupted runs

## Changes

### gitcli layer
- Added `WorktreeAdd`, `WorktreeRemove`, `WorktreePrune` to `Git` interface
- `WorktreeAdd` includes stale worktree recovery via `git worktree prune` + retry
- Added `ErrWorktreeAlreadyExists` sentinel error (covers "already checked out" and "already used by worktree")

### github layer
- Added `ShallowCloneWorktree()` — clones/updates cache on default branch, creates worktree for migration branch
- Extracted `ensureCacheClone` and `addWorktreeForBranch` helpers to reduce cyclomatic complexity
- Discriminated error handling: worktree fallback only triggers on "invalid reference" (branch doesn't exist), pull errors only swallow `ErrReferenceNotFound`
- Added `GitWorktreeRemove()` and `GitWorktreePrune()` thin wrappers

### core layer
- Extended `githubClient` interface with `ShallowCloneWorktree`, `GitWorktreeRemove`, `GitWorktreePrune`
- Split `cloneRepo()` into cached (worktree) and non-cached paths
- Added `getWorktreePath()` helper
- Worktree cleanup in `handleRepo()` defer with `os.RemoveAll` fallback
- Leftover worktree cleanup + prune on next run for interrupted runs

### Tests
- Unit tests for `WorktreeAdd`/`WorktreeRemove` (add, remove, existing branch, stale recovery)
- `parseGitError` test case for worktree sentinel
- Full `TestHandleRepoWithWorktree` integration test verifying push, cleanup, and cache state
- Updated `fakeGit` and `fakeGithubClient` test doubles

### Other
- Reverted Go version to 1.25.0 (go.mod + CircleCI config) for golangci-lint compatibility