### PR TITLE
docs: documentation, examples, and schema improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ banshee merge migration.yaml --config config.yaml
 - `version` - Print banshee CLI version
 - `clone <path>` - Clone all repositories involved in the migration
 - `migrate <path>` - Run the migration actions across repositories
+  - `-j, --concurrency <n>` - Number of repos to process in parallel (requires `cache_repos.enabled: true`)
 - `list <path>` - List PRs associated with a migration
 - `merge <path>` - Merge PRs that pass all branch protections
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ See [docs/migrations.md](docs/migrations.md) for action documentation and [examp
 
 - [Bash script and file template](examples/001_bash-script-add-file-template/) - Run a bash script and add files
 - [CODEOWNERS addition](examples/002_add-codeowners/) - Add CODEOWNERS file to repos
+- [JSON package version bump](examples/003_json-package-version/) - Update package.json version, add a field, and remove a deprecated field
 
 # Documentation
 

--- a/docs/global_config.md
+++ b/docs/global_config.md
@@ -7,7 +7,9 @@
     - [Logging log_level](#logging-log_level)
     - [Assigning code reviewers assign_code_reviewer_if_none_assigned](#assigning-code-reviewers-assign_code_reviewer_if_none_assigned)
     - [Show the output from git commands show_git_output](#show-the-output-from-git-commands-show_git_output)
+    - [Ignoring directories ignore_directories](#ignoring-directories-ignore_directories)
     - [Caching repos cache_repos](#caching-repos-cache_repos)
+    - [Concurrency concurrency](#concurrency-concurrency)
 - [Defaults defaults](#defaults-defaults)
 
 <!-- /TOC -->
@@ -90,6 +92,18 @@ To github.com:TheJokersThief/Banshee.git
    9245979..58616c8  main -> main
 ```
 
+## Ignoring directories (`ignore_directories`)
+
+Lists directories that will be skipped during file-matching actions. This applies to the `replace`, `yaml`, and `json` action types. It does **not** affect `run_command`.
+
+```yaml
+options:
+  ignore_directories:
+    - vendor
+    - node_modules
+    - .git
+```
+
 ## Caching repos (`cache_repos`)
 
 Cloning every repo each time you want to perform a migration can be costly in network and time. To speed things up, you can choose to clone the repo once into the `directory` you choose. Then, when we need to run any migration in the future, it will first pull any new changes from the repo's default branch before running your actions.
@@ -101,6 +115,26 @@ This is particularly appealing if your organisation has several monorepos with l
 We're expecting to run these migrations for thousands of repos, so saving progress allows us to stop and start migrations, run them in batches and recover easily from failures or unexpected changes.
 
 The progress files are serialised in JSON on purpose, instead of a binary format, to allow folks to edit them by hand if they need to. For example, if you want to rerun a migration on only a couple repos, you could change their migration status to false. Or if there's a failure for a repo you can't control, you can manually mark it as completed and deal with it later.
+
+## Concurrency (`concurrency`)
+
+Controls how many repositories are cloned and migrated in parallel. The default is `1` (sequential).
+
+> **Requires `cache_repos.enabled: true`** — parallel workers need a stable on-disk repo cache to avoid conflicting clone operations.
+
+```yaml
+options:
+  concurrency: 4
+  cache_repos:
+    enabled: true
+    directory: "repos.cache"
+```
+
+You can also override this at runtime with the `-j` / `--concurrency` flag:
+
+```bash
+banshee migrate migration.yaml --config config.yaml -j 8
+```
 
 ## Merge options (`merging`)
 

--- a/docs/global_config.md
+++ b/docs/global_config.md
@@ -31,8 +31,8 @@ github:
 
 There are two choices:
 
-* [Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token): Suitable for using your personal account, or a service account. These have a rate limit of 5000 req/s, which is good to keep in mind.
-* [Github Apps](https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/creating-a-github-app): More suitable for mid-to-large organisations. These have a rate limit of 15000 req/s.
+* [Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token): Suitable for using your personal account, or a service account. These have a rate limit of 5,000 req/hr, which is good to keep in mind.
+* [Github Apps](https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/creating-a-github-app): More suitable for mid-to-large organisations. These have a rate limit of 15,000 req/hr.
 
 # Options (`options`)
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,6 +4,7 @@
 <!-- TOC -->
 
 - [Overview](#overview)
+- [Repo Selection](#repo-selection)
 - [Dry-run mode](#dry-run-mode)
 - [Actions](#actions)
   - [Add file](#add-file)
@@ -24,6 +25,31 @@ Migrations should be treated as idempotent, so that you can run the same migrati
 Below is high level flow diagram of how a migration works.
 
 <img src="../images/migration-flow.png" />
+
+# Repo Selection
+
+Exactly one of the following three selectors must be present in each migration config.
+
+| Selector | Type | When to use |
+| -------: | ---- | ----------- |
+| `search_query` | string | Narrow targeting — uses [GitHub code search](https://docs.github.com/en/search-github/searching-on-github/searching-code) syntax to find repos that contain matching content |
+| `all_repos_in_org` | boolean | Broad targeting — applies the migration to **every** repo in the organisation; use with caution |
+| `repos` | list of strings | Explicit targeting — specify the exact repos to migrate; safest default for testing |
+
+```yaml
+# Option 1: GitHub code search query
+search_query: "filename:package.json org:example-org"
+
+# Option 2: All repos in the org (use with caution)
+all_repos_in_org: true
+
+# Option 3: Explicit repo list (recommended for initial testing)
+repos:
+  - example-org/service-a
+  - example-org/service-b
+```
+
+> **Tip:** Start with a `repos` list containing one or two repos, verify the migration behaves as expected, then switch to `search_query` or `all_repos_in_org` for the full rollout.
 
 # Dry-run mode
 

--- a/examples/001_bash-script-add-file-template/migration.yaml
+++ b/examples/001_bash-script-add-file-template/migration.yaml
@@ -5,9 +5,9 @@
 #   - all_repos_in_org (Use every repo in the organisation)
 #   - repos (A static list of repos)
 # search_query: "reference-to-old.url"
-all_repos_in_org: true
-# repos:
-#   - example-org/entity-service
+# all_repos_in_org: true  # WARNING: targets every repo in the org
+repos:
+  - example-org/your-repo-here
 
 organisation: "example-org"
 branch_name: "auto-code-migration/obsv/examples/001_bash-script-add-file-template"

--- a/examples/001_bash-script-add-file-template/migration.yaml
+++ b/examples/001_bash-script-add-file-template/migration.yaml
@@ -12,7 +12,11 @@ repos:
 organisation: "example-org"
 branch_name: "auto-code-migration/obsv/examples/001_bash-script-add-file-template"
 
-actions: 
+# Prerequisites for the add_workflow.sh script:
+#   - yq v4+  (https://github.com/mikefarah/yq#install)
+#   - envsubst (part of gettext; macOS: brew install gettext)
+
+actions:
   - action: run_command
     description: "Add workflow tracing workflow"
     input: 

--- a/examples/002_add-codeowners/migration.yaml
+++ b/examples/002_add-codeowners/migration.yaml
@@ -1,6 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/TheJokersThief/Banshee/main/schemas/migration.json
 
-all_repos_in_org: true
+# You can only choose one of:
+#   - search_query (A GitHub code search query for matching repos)
+#   - all_repos_in_org (Use every repo in the organisation)
+#   - repos (A static list of repos)
+# all_repos_in_org: true  # WARNING: targets every repo in the org
+repos:
+  - example-org/your-repo-here
 
 organisation: "example-org"
 branch_name: "auto-code-migration/qol/add-codeowners"

--- a/examples/003_json-package-version/migration.yaml
+++ b/examples/003_json-package-version/migration.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/TheJokersThief/Banshee/main/schemas/migration.json
+
+# You can only choose one of:
+#   - search_query (A GitHub code search query for matching repos)
+#   - all_repos_in_org (Use every repo in the organisation)
+#   - repos (A static list of repos)
+# search_query: "filename:package.json org:example-org"
+# all_repos_in_org: true  # WARNING: targets every repo in the org
+repos:
+  - example-org/your-repo-here
+
+organisation: "example-org"
+branch_name: "chore/bump-package-version-2-0-0"
+
+actions:
+  - action: json
+    description: "Bump package version to 2.0.0"
+    input:
+      glob: "package.json"
+      sub_action: replace
+      jsonpath: "version"
+      value: "2.0.0"
+  - action: json
+    description: "Add homepage field"
+    input:
+      glob: "package.json"
+      sub_action: add
+      jsonpath: "homepage"
+      value: "https://github.com/example-org/your-repo-here"
+  - action: json
+    description: "Remove deprecated prepublish script"
+    input:
+      glob: "package.json"
+      sub_action: delete
+      jsonpath: "scripts.prepublish"
+
+pr_title: "chore: bump package version to 2.0.0"
+pr_body_file: "examples/003_json-package-version/prbody.md"
+pr_as_drafts: false

--- a/examples/003_json-package-version/prbody.md
+++ b/examples/003_json-package-version/prbody.md
@@ -1,0 +1,10 @@
+# What
+
+- Bumps `version` in `package.json` to `2.0.0`
+- Adds `homepage` field pointing to the GitHub repository
+- Removes the deprecated `scripts.prepublish` field (replaced by `scripts.prepare` in npm 5+)
+
+# Why
+
+- Version 1.x reaches end-of-life and no longer receives security patches
+- The `prepublish` hook ran unexpectedly during `npm install`; removing it in favour of `prepare` fixes this behaviour for all consumers

--- a/examples/migration_config/migration.yaml
+++ b/examples/migration_config/migration.yaml
@@ -23,7 +23,7 @@ actions:
   - action: run_command
     description: "Example command run"
     input: 
-      command: "echo 'Test' > ${MIGRATION_DIR}/test.txt"
+      command: "echo 'Test' > test.txt"
   - action: yaml
     description: "Change a YAML file"
     input: 

--- a/examples/prbody.md
+++ b/examples/prbody.md
@@ -1,7 +1,9 @@
 # What
 
+- Describe the concrete change this PR makes (e.g. "Updates all `package.json` files to use version `2.0.0`")
+
 <!-- changelog -->
 
 # Why
 
-It's for your own good.
+- Explain the motivation for this migration (e.g. "Version 1.x reaches end-of-life on 2025-01-01 and no longer receives security patches")

--- a/examples/project_skeleton/.justfile
+++ b/examples/project_skeleton/.justfile
@@ -11,8 +11,8 @@ install:
 # Create a new migration
 new_migration name:
     mkdir {{ current_timestamp }}_{{ name }}
-    cd {{ current_timestamp }}_{{ name }} && wget -q https://raw.githubusercontent.com/theJokersThief/Banshee/master/examples/migration_config/migration.yaml
+    cd {{ current_timestamp }}_{{ name }} && wget -q https://raw.githubusercontent.com/theJokersThief/Banshee/main/examples/migration_config/migration.yaml
     sed -i '' 's$"examples/prbody.md"$"{{ current_timestamp }}_{{ name }}/prbody.md"$' "{{ current_timestamp }}_{{ name }}/migration.yaml"
     sed -i '' 's$example-org${{ github_org }}$' "{{ current_timestamp }}_{{ name }}/migration.yaml"
-    cd {{ current_timestamp }}_{{ name }} && wget -q https://raw.githubusercontent.com/theJokersThief/Banshee/master/examples/prbody.md
+    cd {{ current_timestamp }}_{{ name }} && wget -q https://raw.githubusercontent.com/theJokersThief/Banshee/main/examples/prbody.md
     @# Created new migration: {{ current_timestamp }}_{{ name }}

--- a/examples/project_skeleton/.justfile
+++ b/examples/project_skeleton/.justfile
@@ -12,7 +12,7 @@ install:
 new_migration name:
     mkdir {{ current_timestamp }}_{{ name }}
     cd {{ current_timestamp }}_{{ name }} && wget -q https://raw.githubusercontent.com/theJokersThief/Banshee/master/examples/migration_config/migration.yaml
-    sed -i '' 's$"examples/prbody.md"$"{{ current_timestamp }}{{ name }}/prbody.md"$' "{{ current_timestamp }}{{ name }}/migration.yaml"
+    sed -i '' 's$"examples/prbody.md"$"{{ current_timestamp }}_{{ name }}/prbody.md"$' "{{ current_timestamp }}_{{ name }}/migration.yaml"
     sed -i '' 's$example-org${{ github_org }}$' "{{ current_timestamp }}_{{ name }}/migration.yaml"
     cd {{ current_timestamp }}_{{ name }} && wget -q https://raw.githubusercontent.com/theJokersThief/Banshee/master/examples/prbody.md
     @# Created new migration: {{ current_timestamp }}_{{ name }}

--- a/examples/project_skeleton/config.yaml
+++ b/examples/project_skeleton/config.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/TheJokersThief/Banshee/main/schemas/global.json
+
+github:
+  use_github_app: false
+  # Personal Access Token — requires repo, read:org, and pull_request scopes
+  token: "ghp_YOUR_PERSONAL_ACCESS_TOKEN_HERE"
+
+  # GitHub App credentials (alternative to PAT — higher rate limits)
+  # app_id: 0
+  # app_installation_id: 0
+  # app_private_key_filepath: ""
+
+options:
+  # Controls the verbosity of log output (debug, info, warn, error)
+  log_level: info
+
+  # Assign a team to review code if no reviewers are already assigned by a CODEOWNERS file
+  assign_code_reviewer_if_none_assigned: false
+
+  # Show the output from all git actions (e.g. clones, pulls and fetches)
+  show_git_output: false
+
+  # Directories skipped during file-matching actions (replace, yaml, json)
+  # Does NOT affect run_command
+  ignore_directories:
+    - vendor
+    - node_modules
+
+  cache_repos:
+    # If enabled, repos are cloned once and reused across migrations
+    # Required for concurrency > 1
+    enabled: false
+    directory: "repos.cache"
+
+  # Concurrency controls how many repos are processed in parallel
+  # Requires cache_repos.enabled: true
+  # Can be overridden at runtime: banshee migrate ... -j 4
+  # concurrency: 1
+
+  save_progress:
+    # Track progress so migrations can be stopped and resumed
+    enabled: true
+    directory: "repos.cache/_progress"
+    # Number of repos to process per batch (-1 disables batching)
+    batch: -1
+
+  merging:
+    # "merge", "squash", or "rebase"
+    strategy: "merge"
+    # Appended to merge commit message (useful for skipping CI)
+    append_title: "[CI SKIP]"
+
+defaults:
+  # The author and commit email
+  git_email: "no-reply@example.com"
+  # The author and commit name
+  git_name: "Example User"
+  # GitHub organisation slug
+  organisation: "your-org"
+  # Team slug to be added as a reviewer
+  code_reviewer: "your-team"

--- a/examples/project_skeleton/prbody.md
+++ b/examples/project_skeleton/prbody.md
@@ -1,0 +1,7 @@
+# What
+
+- Describe the concrete change this PR makes
+
+# Why
+
+- Explain the motivation for this migration

--- a/schemas/global.json
+++ b/schemas/global.json
@@ -5,15 +5,19 @@
         "GlobalConfig": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Banshee global configuration file. Defines GitHub authentication, runtime options, and default values used across all migrations.",
             "properties": {
                 "github": {
-                    "$ref": "#/definitions/Github"
+                    "$ref": "#/definitions/Github",
+                    "description": "GitHub connection configuration."
                 },
                 "options": {
-                    "$ref": "#/definitions/Options"
+                    "$ref": "#/definitions/Options",
+                    "description": "Runtime behaviour options controlling logging, caching, progress, and merge strategy."
                 },
                 "defaults": {
-                    "$ref": "#/definitions/Defaults"
+                    "$ref": "#/definitions/Defaults",
+                    "description": "Default values used when a migration config does not provide them."
                 }
             },
             "required": [
@@ -26,18 +30,23 @@
         "Defaults": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Default values applied when a migration config does not supply them.",
             "properties": {
                 "git_email": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Author email used in git commits."
                 },
                 "git_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Author name used in git commits."
                 },
                 "organisation": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Default GitHub organisation slug used when a migration config does not specify one."
                 },
                 "code_reviewer": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Team slug added as a PR reviewer when assign_code_reviewer_if_none_assigned is true."
                 }
             },
             "required": [
@@ -51,21 +60,27 @@
         "Github": {
             "type": "object",
             "additionalProperties": false,
+            "description": "GitHub authentication configuration. Use either a Personal Access Token or GitHub App credentials.",
             "properties": {
                 "use_github_app": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, authenticates using GitHub App credentials (app_id, app_installation_id, app_private_key_filepath) instead of a Personal Access Token."
                 },
                 "token": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Personal Access Token with repo, read:org, and pull_request scopes. Rate limit: 5,000 req/hr."
                 },
                 "app_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "GitHub App ID. Only used when use_github_app is true."
                 },
                 "app_installation_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "GitHub App installation ID for the target organisation. Only used when use_github_app is true."
                 },
                 "app_private_key_filepath": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Path to the GitHub App private key PEM file. Only used when use_github_app is true."
                 }
             },
             "required": [
@@ -80,30 +95,44 @@
         "Options": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Runtime behaviour options.",
             "properties": {
                 "log_level": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Verbosity of log output. Valid values: debug, info, warn, error. Default: info.",
+                    "enum": ["debug", "info", "warn", "error"]
                 },
                 "assign_code_reviewer_if_none_assigned": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, assigns the defaults.code_reviewer team as a PR reviewer if no reviewers are assigned automatically via CODEOWNERS."
                 },
                 "show_git_output": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, prints output from git operations (clone, pull, fetch) to the console."
                 },
                 "ignore_directories": {
                     "type": "array",
+                    "description": "Directory names skipped during file-matching actions (replace, yaml, json). Does not affect run_command.",
                     "items": {
                         "type": "string"
                     }
                 },
+                "concurrency": {
+                    "type": "integer",
+                    "description": "Number of repositories to clone and migrate in parallel. Requires cache_repos.enabled: true. Can be overridden at runtime with the -j / --concurrency flag. Default: 1.",
+                    "minimum": 1
+                },
                 "cache_repos": {
-                    "$ref": "#/definitions/CacheRepos"
+                    "$ref": "#/definitions/CacheRepos",
+                    "description": "Configuration for persistent on-disk repo caching."
                 },
                 "save_progress": {
-                    "$ref": "#/definitions/SaveProgress"
+                    "$ref": "#/definitions/SaveProgress",
+                    "description": "Configuration for progress tracking, allowing migrations to be stopped and resumed."
                 },
                 "merging": {
-                    "$ref": "#/definitions/Merging"
+                    "$ref": "#/definitions/Merging",
+                    "description": "Configuration for the merge command behaviour."
                 }
             },
             "required": [
@@ -119,12 +148,15 @@
         "CacheRepos": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Persistent repo cache settings. When enabled, repos are cloned once and reused across migrations by pulling the latest default branch changes before each run.",
             "properties": {
                 "enabled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, repos are cloned once and stored on disk for reuse. Required for concurrency > 1."
                 },
                 "directory": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Filesystem path for storing the cloned repos cache."
                 }
             },
             "required": [
@@ -136,12 +168,16 @@
         "Merging": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Options for the merge command.",
             "properties": {
                 "strategy": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Merge strategy for the merge command. Valid values: merge, squash, rebase.",
+                    "enum": ["merge", "squash", "rebase"]
                 },
                 "append_title": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "String appended to the merge commit title. Useful for skipping CI (e.g. \"[CI SKIP]\")."
                 }
             },
             "required": [
@@ -153,15 +189,19 @@
         "SaveProgress": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Progress tracking settings. Progress files are serialised JSON and can be edited by hand to rerun or skip specific repos.",
             "properties": {
                 "enabled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, migration progress is tracked on disk so runs can be stopped and resumed."
                 },
                 "directory": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Filesystem path for storing progress files."
                 },
                 "batch": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Number of repos to process per run. Use -1 to disable batching and process all repos in one run."
                 }
             },
             "required": [

--- a/schemas/migration.json
+++ b/schemas/migration.json
@@ -5,39 +5,49 @@
         "MigrationConfig": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Banshee migration configuration. Defines the target repositories, actions to perform, and pull request details.",
             "properties": {
                 "search_query": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "GitHub code search query used to select target repositories (e.g. \"filename:package.json org:example-org\"). Mutually exclusive with all_repos_in_org and repos."
                 },
                 "all_repos_in_org": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, targets every repository in the organisation. Use with caution. Mutually exclusive with search_query and repos."
                 },
                 "repos": {
                     "type": "array",
+                    "description": "Explicit list of repositories to migrate (format: org/repo). Recommended for initial testing. Mutually exclusive with search_query and all_repos_in_org.",
                     "items": {
                         "type": "string"
                     }
                 },
                 "organisation": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "GitHub organisation slug. Used as the default for repo operations when not inferred from the repo selector."
                 },
                 "branch_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the branch created in each target repository for the migration changes."
                 },
                 "actions": {
                     "type": "array",
+                    "description": "Ordered list of actions to perform on each repository. Each action produces a commit if it changes any files.",
                     "items": {
                         "$ref": "#/definitions/Action"
                     }
                 },
                 "pr_title": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Title of the pull request opened for this migration."
                 },
                 "pr_body_file": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Path to a Markdown file used as the pull request body. Resolved relative to the working directory from which Banshee is invoked."
                 },
                 "pr_as_drafts": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, pull requests are created as drafts."
                 }
             },
             "required": [
@@ -53,14 +63,19 @@
         "Action": {
             "type": "object",
             "additionalProperties": false,
+            "description": "A single action to perform on each target repository.",
             "properties": {
                 "action": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Action type to perform.",
+                    "enum": ["replace", "run_command", "yaml", "json", "add_file"]
                 },
                 "description": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Commit message used when this action produces file changes."
                 },
                 "input": {
+                    "description": "Input parameters for the action. Shape depends on the action type.",
                     "oneOf": [
                         {
                             "$ref": "#/definitions/ReplaceInput"
@@ -90,15 +105,19 @@
         "ReplaceInput": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Input for the replace action. Performs a literal find-and-replace across matching files.",
             "properties": {
                 "old": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "String to search for and replace."
                 },
                 "new": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Replacement string."
                 },
                 "glob": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Glob pattern selecting which files to apply the replacement to. Default: **."
                 }
             },
             "required": ["old", "new"],
@@ -107,9 +126,11 @@
         "RunCommandInput": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Input for the run_command action. Executes an arbitrary bash command inside the cloned repository.",
             "properties": {
                 "command": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Bash command to execute. Runs with the cloned repo as the working directory. The MIGRATION_DIR environment variable is set to the directory containing the migration YAML file."
                 }
             },
             "required": ["command"],
@@ -118,19 +139,24 @@
         "YAMLInput": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Input for the yaml action. Makes targeted changes to YAML files using dot-notation paths.",
             "properties": {
                 "glob": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Glob pattern selecting which YAML files to modify."
                 },
                 "sub_action": {
                     "type": "string",
+                    "description": "YAML operation to perform.",
                     "enum": ["replace", "add", "delete", "list_append"]
                 },
                 "yamlpath": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Dot-notation path to the target key (e.g. firstlevel.secondlevel)."
                 },
                 "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value to set. Not required for the delete sub_action."
                 }
             },
             "required": ["glob", "sub_action", "yamlpath"],
@@ -139,11 +165,25 @@
         "JSONInput": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Input for the json action. Makes targeted changes to JSON files using dot-notation paths while preserving key order and formatting.",
             "properties": {
-                "glob":       { "type": "string" },
-                "sub_action": { "type": "string", "enum": ["replace", "add", "delete", "list_append"] },
-                "jsonpath":   { "type": "string" },
-                "value":      { "type": "string" }
+                "glob": {
+                    "type": "string",
+                    "description": "Glob pattern selecting which JSON files to modify. Default: **/*.json."
+                },
+                "sub_action": {
+                    "type": "string",
+                    "description": "JSON operation to perform.",
+                    "enum": ["replace", "add", "delete", "list_append"]
+                },
+                "jsonpath": {
+                    "type": "string",
+                    "description": "Dot-notation path to the target key (e.g. scripts.build)."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "Value to set. Not required for the delete sub_action. For list_append, the target path must already exist and be an array."
+                }
             },
             "required": ["sub_action", "jsonpath"],
             "title": "JSONInput"
@@ -151,9 +191,16 @@
         "AddFileInput": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Input for the add_file action. Creates a new file in the repository with the specified content.",
             "properties": {
-                "file":    { "type": "string" },
-                "content": { "type": "string" }
+                "file": {
+                    "type": "string",
+                    "description": "Path and filename to create, relative to the repository root (e.g. .github/workflows/ci.yml)."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to write to the new file."
+                }
             },
             "required": ["file", "content"],
             "title": "AddFileInput"

--- a/schemas/migration.json
+++ b/schemas/migration.json
@@ -73,6 +73,9 @@
                         },
                         {
                             "$ref": "#/definitions/JSONInput"
+                        },
+                        {
+                            "$ref": "#/definitions/AddFileInput"
                         }
                     ]
                 }
@@ -120,7 +123,8 @@
                     "type": "string"
                 },
                 "sub_action": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": ["replace", "add", "delete", "list_append"]
                 },
                 "yamlpath": {
                     "type": "string"
@@ -143,6 +147,16 @@
             },
             "required": ["sub_action", "jsonpath"],
             "title": "JSONInput"
+        },
+        "AddFileInput": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "file":    { "type": "string" },
+                "content": { "type": "string" }
+            },
+            "required": ["file", "content"],
+            "title": "AddFileInput"
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Schema**: Add `AddFileInput` definition to `migration.json`; add `enum` constraints to `YAMLInput.sub_action`, `Action.action`, `Options.log_level`, and `Merging.strategy`; add `description` properties to all fields in both `global.json` and `migration.json` for IDE tooltip support; add missing `Options.concurrency` to `global.json`
- **Examples**: Fix path bug in `project_skeleton/.justfile`, fix `run_command` writing to wrong dir in `migration_config` example, replace placeholder PR body text, swap dangerous `all_repos_in_org: true` default to safe `repos:` list in examples 001 and 002, add new `003_json-package-version` example, add `project_skeleton/config.yaml` and `project_skeleton/prbody.md` templates
- **Docs**: Add `ignore_directories` and `concurrency` subsections to `global_config.md`; add `Repo Selection` section to `migrations.md`; fix rate limit units (`req/s` → `req/hr`); fix `justfile` wget to use `main` branch; add prerequisites comment to example 001; update README with concurrency flag and new example link