### PR TITLE
Fix stale worktree directory recovery and skip pull for new branches

### DIFF
--- a/pkg/gitcli/exec.go
+++ b/pkg/gitcli/exec.go
@@ -205,13 +205,13 @@ func (g *ExecGit) WorktreeAdd(repoDir, worktreeDir, branch string, create bool) 
 		// Stale worktree from a previous interrupted run — force-remove,
 		// prune metadata, delete the physical directory, then retry.
 		// WorktreeRemove may fail if git no longer tracks this worktree; that's fine.
-		g.run("", "-C", repoDir, "worktree", "remove", "--force", worktreeDir)
+		_, _ = g.run("", "-C", repoDir, "worktree", "remove", "--force", worktreeDir)
 		if _, pruneErr := g.run("", "-C", repoDir, "worktree", "prune"); pruneErr != nil {
 			return fmt.Errorf("pruning stale worktrees before retry: %w", pruneErr)
 		}
 		// Remove the physical directory if it still exists (covers the case
 		// where only the directory remains but git's worktree metadata is gone).
-		os.RemoveAll(worktreeDir)
+		_ = os.RemoveAll(worktreeDir)
 		_, err = g.run("", args...)
 	}
 	return err

--- a/pkg/gitcli/exec.go
+++ b/pkg/gitcli/exec.go
@@ -112,14 +112,18 @@ func (g *ExecGit) Checkout(dir, branch string, create bool) error {
 	return err
 }
 
-// Fetch fetches branch from the given URL. ErrRemoteRefNotFound,
-// ErrAlreadyUpToDate, "refusing to fetch into current branch", and
-// "shallow update not allowed" are swallowed.
-func (g *ExecGit) Fetch(dir, tokenURL, branch string) error {
+// Fetch fetches branch from the given URL. Returns true if the branch was
+// found on the remote, false if it does not exist. ErrAlreadyUpToDate,
+// "refusing to fetch into current branch", and "shallow update not allowed"
+// are swallowed (branch is considered found in those cases).
+func (g *ExecGit) Fetch(dir, tokenURL, branch string) (bool, error) {
 	refspec := fmt.Sprintf("%s:%s", branch, branch)
 	_, err := g.run(dir, "fetch", tokenURL, refspec)
-	if errors.Is(err, ErrRemoteRefNotFound) || errors.Is(err, ErrAlreadyUpToDate) {
-		return nil
+	if errors.Is(err, ErrRemoteRefNotFound) {
+		return false, nil
+	}
+	if errors.Is(err, ErrAlreadyUpToDate) {
+		return true, nil
 	}
 	// When we are already on the target branch git refuses to update it via
 	// refspec. Pull handles the actual sync in that case.
@@ -128,10 +132,10 @@ func (g *ExecGit) Fetch(dir, tokenURL, branch string) error {
 	if errors.As(err, &ge) {
 		if strings.Contains(ge.Stderr, "refusing to fetch") ||
 			strings.Contains(ge.Stderr, "shallow update not allowed") {
-			return nil
+			return true, nil
 		}
 	}
-	return err
+	return err == nil, err
 }
 
 // Pull hard-resets HEAD then fast-forward pulls from the given URL.
@@ -197,14 +201,31 @@ func (g *ExecGit) WorktreeAdd(repoDir, worktreeDir, branch string, create bool) 
 	}
 
 	_, err := g.run("", args...)
-	if errors.Is(err, ErrWorktreeAlreadyExists) {
-		// Stale worktree from a previous interrupted run — prune stale references and retry.
+	if isWorktreeExistsErr(err) {
+		// Stale worktree from a previous interrupted run — force-remove,
+		// prune metadata, delete the physical directory, then retry.
+		// WorktreeRemove may fail if git no longer tracks this worktree; that's fine.
+		g.run("", "-C", repoDir, "worktree", "remove", "--force", worktreeDir)
 		if _, pruneErr := g.run("", "-C", repoDir, "worktree", "prune"); pruneErr != nil {
 			return fmt.Errorf("pruning stale worktrees before retry: %w", pruneErr)
 		}
+		// Remove the physical directory if it still exists (covers the case
+		// where only the directory remains but git's worktree metadata is gone).
+		os.RemoveAll(worktreeDir)
 		_, err = g.run("", args...)
 	}
 	return err
+}
+
+// isWorktreeExistsErr returns true when git reports the worktree (or its
+// target path) already exists — either because the worktree is still tracked
+// by git or because the directory remains from an interrupted run.
+func isWorktreeExistsErr(err error) bool {
+	if errors.Is(err, ErrWorktreeAlreadyExists) {
+		return true
+	}
+	var ge *GitError
+	return errors.As(err, &ge) && strings.Contains(ge.Stderr, "already exists")
 }
 
 // WorktreeRemove forcefully removes a git worktree.

--- a/pkg/gitcli/exec_test.go
+++ b/pkg/gitcli/exec_test.go
@@ -151,7 +151,9 @@ func TestFetch(t *testing.T) {
 	require.NoError(t, newGit(t).Clone(bareDir, local, branch, 0))
 
 	// Fetch the feature branch into the local repo.
-	require.NoError(t, newGit(t).Fetch(local, bareDir, "feature-branch"))
+	found, err := newGit(t).Fetch(local, bareDir, "feature-branch")
+	require.NoError(t, err)
+	assert.True(t, found, "branch exists on remote, should return true")
 
 	// Verify the local branch was created.
 	out, err := exec.Command("git", "-C", local, "branch").Output()
@@ -169,8 +171,10 @@ func TestFetchNonexistentBranch(t *testing.T) {
 	local := filepath.Join(t.TempDir(), "local")
 	require.NoError(t, newGit(t).Clone(bareDir, local, branch, 0))
 
-	// Fetching a branch that doesn't exist should return nil (error swallowed).
-	require.NoError(t, newGit(t).Fetch(local, bareDir, "does-not-exist"))
+	// Fetching a branch that doesn't exist should return false (not found).
+	found, err := newGit(t).Fetch(local, bareDir, "does-not-exist")
+	require.NoError(t, err)
+	assert.False(t, found, "branch does not exist on remote, should return false")
 }
 
 func TestFetchOnCurrentBranch(t *testing.T) {
@@ -180,8 +184,10 @@ func TestFetchOnCurrentBranch(t *testing.T) {
 	local := filepath.Join(t.TempDir(), "local")
 	require.NoError(t, newGit(t).Clone(bareDir, local, branch, 0))
 
-	// We are on `branch`; fetching branch:branch should be swallowed.
-	require.NoError(t, newGit(t).Fetch(local, bareDir, branch))
+	// We are on `branch`; fetching branch:branch should be swallowed (branch exists).
+	found, err := newGit(t).Fetch(local, bareDir, branch)
+	require.NoError(t, err)
+	assert.True(t, found, "current branch exists on remote, should return true")
 }
 
 // ── Pull ─────────────────────────────────────────────────────────────────────
@@ -392,6 +398,33 @@ func TestWorktreeAddStaleRecovery(t *testing.T) {
 
 	// Cleanup.
 	require.NoError(t, g.WorktreeRemove(repoDir, wtDir2))
+}
+
+func TestWorktreeAddStaleDirectoryRecovery(t *testing.T) {
+	bareDir, branch := initBareWithContent(t)
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, newGit(t).Clone(bareDir, repoDir, branch, 0))
+
+	g := newGit(t)
+
+	// Create a worktree, then prune its metadata but leave the directory on disk.
+	// This simulates the state left behind by a previous interrupted run where
+	// git no longer tracks the worktree but the physical directory remains.
+	wtDir := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, g.WorktreeAdd(repoDir, wtDir, "leftover-branch", true))
+	require.NoError(t, g.WorktreeRemove(repoDir, wtDir))
+	// Re-create the directory to simulate the leftover.
+	require.NoError(t, os.MkdirAll(wtDir, 0755))
+
+	// WorktreeAdd should recover by removing the stale directory and retrying.
+	require.NoError(t, g.WorktreeAdd(repoDir, wtDir, "leftover-branch", false))
+
+	assert.DirExists(t, wtDir)
+	assert.Equal(t, "leftover-branch", headBranch(t, wtDir))
+
+	// Cleanup.
+	require.NoError(t, g.WorktreeRemove(repoDir, wtDir))
 }
 
 // ── parseGitError ─────────────────────────────────────────────────────────────

--- a/pkg/gitcli/git.go
+++ b/pkg/gitcli/git.go
@@ -13,7 +13,7 @@ var (
 type Git interface {
 	Clone(tokenURL, dir, branch string, depth int) error
 	Checkout(dir, branch string, create bool) error
-	Fetch(dir, tokenURL, branch string) error
+	Fetch(dir, tokenURL, branch string) (bool, error)
 	Pull(dir, tokenURL, branch string) error
 	Push(dir, tokenURL, branch string) error
 	IsClean(dir string) (bool, error)

--- a/pkg/github/git_test.go
+++ b/pkg/github/git_test.go
@@ -48,9 +48,9 @@ func (f *fakeGit) Checkout(dir, branch string, create bool) error {
 	f.checkoutArgs = &checkoutCall{dir, branch, create}
 	return f.err
 }
-func (f *fakeGit) Fetch(dir, tokenURL, branch string) error {
+func (f *fakeGit) Fetch(dir, tokenURL, branch string) (bool, error) {
 	f.fetchArgs = &fetchCall{dir, tokenURL, branch}
-	return f.err
+	return f.err == nil, f.err
 }
 func (f *fakeGit) Pull(dir, tokenURL, branch string) error {
 	f.pullArgs = &pullCall{dir, tokenURL, branch}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -158,11 +158,14 @@ func (gc *GithubClient) ShallowClone(org, repoName, dir, migrationBranchName str
 	if err != nil {
 		return "", err
 	}
-	if err := gc.git.Fetch(dir, migURL, migrationBranchName); err != nil {
+	found, err := gc.git.Fetch(dir, migURL, migrationBranchName)
+	if err != nil {
 		return "", err
 	}
-	if err := gc.git.Pull(dir, migURL, migrationBranchName); err != nil {
-		return "", err
+	if found {
+		if err := gc.git.Pull(dir, migURL, migrationBranchName); err != nil {
+			return "", err
+		}
 	}
 
 	return defaultBranch, nil
@@ -215,12 +218,13 @@ func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDi
 		return "", err
 	}
 
-	// Fetch the migration branch from remote (swallow "not found").
+	// Fetch the migration branch from remote (returns false when branch is new).
 	fetchURL, err := gc.freshTokenURL(org, repoName)
 	if err != nil {
 		return "", err
 	}
-	if err := gc.git.Fetch(cacheDir, fetchURL, migrationBranchName); err != nil {
+	remoteExists, err := gc.git.Fetch(cacheDir, fetchURL, migrationBranchName)
+	if err != nil {
 		return "", err
 	}
 
@@ -228,16 +232,16 @@ func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDi
 		return "", err
 	}
 
-	// If the branch existed remotely, pull latest into the worktree.
-	pullURL, err := gc.freshTokenURL(org, repoName)
-	if err != nil {
-		return "", err
-	}
-	if pullErr := gc.git.Pull(worktreeDir, pullURL, migrationBranchName); pullErr != nil {
-		// ErrReferenceNotFound means the branch is new (local only) — safe to ignore.
-		if !errors.Is(pullErr, gitcli.ErrReferenceNotFound) {
-			return "", pullErr
+	// Only pull if the branch existed on the remote.
+	if remoteExists {
+		pullURL, err := gc.freshTokenURL(org, repoName)
+		if err != nil {
+			return "", err
 		}
+		if err := gc.git.Pull(worktreeDir, pullURL, migrationBranchName); err != nil {
+			return "", err
+		}
+	} else {
 		gc.log.Debug("Migration branch is new, skipping pull in worktree")
 	}
 


### PR DESCRIPTION
# What

- `WorktreeAdd` now recovers from leftover directories on disk (not just stale git worktree metadata) by force-removing the worktree, pruning, and deleting the physical directory before retrying
- `Fetch` returns a `(found bool, err error)` so callers know whether the branch exists on the remote
- `ShallowClone` and `ShallowCloneWorktree` skip the `Pull` step entirely when the branch is new (local only)

# Why

- When a previous migration run was interrupted, the worktree directory could be left on disk while git's metadata was already cleaned up. `git worktree add` fails with `fatal: 'path' already exists` which wasn't detected by the existing recovery logic (only `already checked out` / `already used by worktree` were handled).
- After fixing the worktree issue, a second bug was exposed: `Pull` was called unconditionally even when the branch didn't exist on the remote, causing `git pull --ff-only` to fail with an unrecognised error (empty stderr, exit code non-zero). Having `Fetch` report whether the branch was found avoids the blind pull entirely.