### PR TITLE
Fix worktree paths resolving relative to git -C directory

### DIFF
--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -333,13 +333,23 @@ func (b *Banshee) commitIfDirty(log *logrus.Entry, dir, message string) (bool, e
 }
 
 func (b *Banshee) getCacheRepoPath(org, repo string) string {
-	return fmt.Sprintf("%s/%s-%s", b.GlobalConfig.Options.CacheRepos.Directory, org, repo)
+	path := fmt.Sprintf("%s/%s-%s", b.GlobalConfig.Options.CacheRepos.Directory, org, repo)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return abs
 }
 
 func (b *Banshee) getWorktreePath(org, repo string) string {
 	safeBranch := strings.ReplaceAll(b.MigrationConfig.BranchName, "/", "-")
-	return fmt.Sprintf("%s/%s-%s-wt/%s",
+	path := fmt.Sprintf("%s/%s-%s-wt/%s",
 		b.GlobalConfig.Options.CacheRepos.Directory, org, repo, safeBranch)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return abs
 }
 
 // Handle the migration for a repo


### PR DESCRIPTION
# What

- Convert `getCacheRepoPath()` and `getWorktreePath()` return values from relative to absolute paths using `filepath.Abs()`

# Why

- When `cache_repos` is enabled, `git -C <repoDir> worktree add <worktreeDir>` interprets the relative `worktreeDir` relative to `repoDir`, nesting the worktree inside the cache repo (e.g. `repos.cache/org-repo/repos.cache/org-repo-wt/branch`)
- Later, `RunCommand.Run()` sets `cmd.Dir` using the original relative path from project root, which doesn't match the nested location, causing `chdir: no such file or directory`
- Using absolute paths ensures both git and the action runner resolve to the same location