### PR TITLE
Make migration runs idempotent with reset-and-replay

### DIFF
--- a/docs/global_config.md
+++ b/docs/global_config.md
@@ -106,7 +106,7 @@ options:
 
 ## Caching repos (`cache_repos`)
 
-Cloning every repo each time you want to perform a migration can be costly in network and time. To speed things up, you can choose to clone the repo once into the `directory` you choose. Then, when we need to run any migration in the future, it will first pull any new changes from the repo's default branch before running your actions.
+Cloning every repo each time you want to perform a migration can be costly in network and time. To speed things up, you can choose to clone the repo once into the `directory` you choose. Then, when we need to run any migration in the future, it will pull the latest default branch into the cache and reset the migration branch to it before running your actions. Each run produces a clean set of commits from the migration YAML.
 
 This is particularly appealing if your organisation has several monorepos with long git histories.
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -20,7 +20,7 @@
 
 Every migration performs a set of actions on the repo. Actions do things like find and replace text, or run a premade command/script. If the action changed anything, we push the changes to a branch and cut a new Pull Request on GitHub to propose the changes to codeowners.
 
-Migrations should be treated as idempotent, so that you can run the same migration several times but only have exact same changes made each time. 
+Migrations are idempotent. Every run resets the migration branch to the default branch and replays all actions from scratch, producing a clean, deterministic set of commits derived entirely from the migration YAML. This means you can safely re-run a migration after editing the YAML (adding, removing, or reordering actions) without producing duplicate commits. The resulting branch is force-pushed to the remote.
 
 Below is high level flow diagram of how a migration works.
 
@@ -61,7 +61,8 @@ banshee migrate -d migration.yaml
 ```
 
 In dry-run mode Banshee:
-- Clones every target repo and applies all actions exactly as normal
+- Clones every target repo, resets the migration branch to the default branch, and applies all actions exactly as normal
+- Resets the working tree between actions so each action's diff is evaluated independently
 - Logs `[dry-run] Would commit: <description>` for each action that produced changes, instead of creating a commit
 - Logs `[dry-run] Would push branch and open/update PR for <repo>` instead of pushing or touching GitHub
 - Does **not** update the progress file, so re-running without `--dry-run` will process the full repo list again

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -23,6 +23,7 @@ type githubClient interface {
 	GitIsClean(dir string) (bool, error)
 	GitAddAll(dir string) error
 	GitCommit(dir, message, name, email string) error
+	GitResetToRef(dir, ref string) error
 	Push(branch, dir, org, repoName string) error
 	FindPullRequest(org, repo, baseBranch, headBranch string) (*gogithub.PullRequest, error)
 	CreatePullRequest(org, repo, title, body, baseBranch, mergeBranch string, asDraft bool) (string, error)

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -302,6 +302,11 @@ func (b *Banshee) applyActionAndCommit(log *logrus.Entry, dir, actionID, descrip
 		}
 		if !isClean {
 			log.Info("[dry-run] Would commit: ", description)
+			// Clean the working tree so uncommitted changes from this action
+			// don't leak into the next action's diff check.
+			if resetErr := b.GithubClient.GitResetToRef(dir, "HEAD"); resetErr != nil {
+				return false, resetErr
+			}
 			return true, nil
 		}
 		return false, nil

--- a/pkg/core/migrate_test.go
+++ b/pkg/core/migrate_test.go
@@ -122,6 +122,9 @@ func (f *fakeGithubClient) GitAddAll(dir string) error            { return f.git
 func (f *fakeGithubClient) GitCommit(dir, msg, name, email string) error {
 	return f.git.Commit(dir, msg, name, email)
 }
+func (f *fakeGithubClient) GitResetToRef(dir, ref string) error {
+	return f.git.ResetToRef(dir, ref)
+}
 func (f *fakeGithubClient) Push(branch, dir, _, _ string) error {
 	f.pushCallCount.Add(1)
 	return f.git.Push(dir, f.bareRepoURL, branch)

--- a/pkg/gitcli/exec.go
+++ b/pkg/gitcli/exec.go
@@ -155,7 +155,7 @@ func (g *ExecGit) Pull(dir, tokenURL, branch string) error {
 // Push pushes the current HEAD to branch on the remote using an unambiguous
 // refs/heads/ refspec. ErrAlreadyUpToDate is swallowed.
 func (g *ExecGit) Push(dir, tokenURL, branch string) error {
-	_, err := g.run(dir, "push", tokenURL, "HEAD:refs/heads/"+branch)
+	_, err := g.run(dir, "push", "--force", tokenURL, "HEAD:refs/heads/"+branch)
 	if errors.Is(err, ErrAlreadyUpToDate) {
 		return nil
 	}

--- a/pkg/gitcli/exec.go
+++ b/pkg/gitcli/exec.go
@@ -162,6 +162,13 @@ func (g *ExecGit) Push(dir, tokenURL, branch string) error {
 	return err
 }
 
+// ResetToRef hard-resets the current branch to the given ref (branch name,
+// tag, or commit SHA). All uncommitted changes are discarded.
+func (g *ExecGit) ResetToRef(dir, ref string) error {
+	_, err := g.run(dir, "reset", "--hard", ref)
+	return err
+}
+
 // IsClean returns true when the working tree has no changes.
 func (g *ExecGit) IsClean(dir string) (bool, error) {
 	out, err := g.run(dir, "status", "--porcelain")

--- a/pkg/gitcli/exec_test.go
+++ b/pkg/gitcli/exec_test.go
@@ -246,6 +246,36 @@ func TestPush(t *testing.T) {
 	assert.FileExists(t, filepath.Join(verify, "pushed.txt"))
 }
 
+func TestPushForceOverwritesDivergedHistory(t *testing.T) {
+	bareDir, branch := initBareWithContent(t)
+
+	// Clone to local and make a commit.
+	local := filepath.Join(t.TempDir(), "local")
+	require.NoError(t, newGit(t).Clone(bareDir, local, branch, 0))
+	runCmd(t, "git", "-C", local, "config", "user.email", "test@example.com")
+	runCmd(t, "git", "-C", local, "config", "user.name", "Test User")
+
+	require.NoError(t, os.WriteFile(filepath.Join(local, "a.txt"), []byte("a"), 0644))
+	require.NoError(t, newGit(t).AddAll(local))
+	require.NoError(t, newGit(t).Commit(local, "local commit", "Test User", "test@example.com"))
+	require.NoError(t, newGit(t).Push(local, bareDir, branch))
+
+	// Reset local to before the commit, add a different commit — history diverges.
+	require.NoError(t, newGit(t).ResetToRef(local, "HEAD~1"))
+	require.NoError(t, os.WriteFile(filepath.Join(local, "b.txt"), []byte("b"), 0644))
+	require.NoError(t, newGit(t).AddAll(local))
+	require.NoError(t, newGit(t).Commit(local, "diverged commit", "Test User", "test@example.com"))
+
+	// Push should succeed (force) even though history diverged.
+	require.NoError(t, newGit(t).Push(local, bareDir, branch))
+
+	// Verify the bare repo has b.txt (from the force-push) and not a.txt.
+	verify := filepath.Join(t.TempDir(), "verify")
+	runCmd(t, "git", "clone", bareDir, verify)
+	assert.FileExists(t, filepath.Join(verify, "b.txt"))
+	assert.NoFileExists(t, filepath.Join(verify, "a.txt"))
+}
+
 // ── ResetToRef ───────────────────────────────────────────────────────────────
 
 func TestResetToRef(t *testing.T) {

--- a/pkg/gitcli/exec_test.go
+++ b/pkg/gitcli/exec_test.go
@@ -246,6 +246,59 @@ func TestPush(t *testing.T) {
 	assert.FileExists(t, filepath.Join(verify, "pushed.txt"))
 }
 
+// ── ResetToRef ───────────────────────────────────────────────────────────────
+
+func TestResetToRef(t *testing.T) {
+	dir := t.TempDir()
+	branch := initRepo(t, dir)
+	g := newGit(t)
+
+	// Create a file and commit it.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("v1"), 0644))
+	require.NoError(t, g.AddAll(dir))
+	require.NoError(t, g.Commit(dir, "add file", "Test", "test@example.com"))
+
+	// Record the current HEAD.
+	headAfterCommit := runCmd(t, "git", "-C", dir, "rev-parse", "HEAD")
+
+	// Add another commit so HEAD moves forward.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("v2"), 0644))
+	require.NoError(t, g.AddAll(dir))
+	require.NoError(t, g.Commit(dir, "update file", "Test", "test@example.com"))
+
+	// Reset back to the first commit.
+	require.NoError(t, g.ResetToRef(dir, headAfterCommit))
+
+	// HEAD should now match the earlier commit.
+	headNow := runCmd(t, "git", "-C", dir, "rev-parse", "HEAD")
+	assert.Equal(t, headAfterCommit, headNow)
+
+	// File content should match the first commit.
+	content, err := os.ReadFile(filepath.Join(dir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "v1", string(content))
+
+	_ = branch // silence unused
+}
+
+func TestResetToRefBranchName(t *testing.T) {
+	dir := t.TempDir()
+	branch := initRepo(t, dir)
+	g := newGit(t)
+
+	// Add a commit on a feature branch.
+	require.NoError(t, g.Checkout(dir, "feature", true))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "feat.txt"), []byte("feature"), 0644))
+	require.NoError(t, g.AddAll(dir))
+	require.NoError(t, g.Commit(dir, "feature commit", "Test", "test@example.com"))
+
+	// Reset the feature branch back to the default branch.
+	require.NoError(t, g.ResetToRef(dir, branch))
+
+	// feat.txt should no longer exist.
+	assert.NoFileExists(t, filepath.Join(dir, "feat.txt"))
+}
+
 // ── IsClean ───────────────────────────────────────────────────────────────────
 
 func TestIsClean(t *testing.T) {

--- a/pkg/gitcli/git.go
+++ b/pkg/gitcli/git.go
@@ -16,6 +16,7 @@ type Git interface {
 	Fetch(dir, tokenURL, branch string) (bool, error)
 	Pull(dir, tokenURL, branch string) error
 	Push(dir, tokenURL, branch string) error
+	ResetToRef(dir, ref string) error
 	IsClean(dir string) (bool, error)
 	AddAll(dir string) error
 	Commit(dir, message, authorName, authorEmail string) error

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -28,6 +28,11 @@ func (gc *GithubClient) GitCommit(dir, message, name, email string) error {
 	return gc.git.Commit(dir, message, name, email)
 }
 
+// GitResetToRef hard-resets the current branch to the given ref.
+func (gc *GithubClient) GitResetToRef(dir, ref string) error {
+	return gc.git.ResetToRef(dir, ref)
+}
+
 // GitWorktreeRemove removes a git worktree from the given repo directory.
 func (gc *GithubClient) GitWorktreeRemove(repoDir, worktreeDir string) error {
 	return gc.git.WorktreeRemove(repoDir, worktreeDir)

--- a/pkg/github/git_test.go
+++ b/pkg/github/git_test.go
@@ -24,6 +24,7 @@ type fakeGit struct {
 	commitArgs        *commitCall
 	worktreeAddArgs   *worktreeAddCall
 	worktreeRemoveArgs *worktreeRemoveCall
+	resetToRefArgs    *resetToRefCall
 
 	isCleanResult bool
 	err           error
@@ -39,6 +40,7 @@ type addAllCall  struct{ dir string }
 type commitCall        struct{ dir, message, name, email string }
 type worktreeAddCall   struct{ repoDir, worktreeDir, branch string; create bool }
 type worktreeRemoveCall struct{ repoDir, worktreeDir string }
+type resetToRefCall    struct{ dir, ref string }
 
 func (f *fakeGit) Clone(tokenURL, dir, branch string, depth int) error {
 	f.cloneArgs = &cloneCall{tokenURL, dir, branch, depth}
@@ -81,6 +83,10 @@ func (f *fakeGit) WorktreeRemove(repoDir, worktreeDir string) error {
 	return f.err
 }
 func (f *fakeGit) WorktreePrune(_ string) error {
+	return f.err
+}
+func (f *fakeGit) ResetToRef(dir, ref string) error {
+	f.resetToRefArgs = &resetToRefCall{dir, ref}
 	return f.err
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -153,19 +153,10 @@ func (gc *GithubClient) ShallowClone(org, repoName, dir, migrationBranchName str
 		return "", err
 	}
 
-	// Refresh token before migration-branch network ops.
-	migURL, err := gc.freshTokenURL(org, repoName)
-	if err != nil {
+	// Always reset the migration branch to the default branch so every run
+	// produces a clean, deterministic set of commits from the migration YAML.
+	if err := gc.git.ResetToRef(dir, defaultBranch); err != nil {
 		return "", err
-	}
-	found, err := gc.git.Fetch(dir, migURL, migrationBranchName)
-	if err != nil {
-		return "", err
-	}
-	if found {
-		if err := gc.git.Pull(dir, migURL, migrationBranchName); err != nil {
-			return "", err
-		}
 	}
 
 	return defaultBranch, nil

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -214,7 +214,7 @@ func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDi
 	if err != nil {
 		return "", err
 	}
-	remoteExists, err := gc.git.Fetch(cacheDir, fetchURL, migrationBranchName)
+	_, err = gc.git.Fetch(cacheDir, fetchURL, migrationBranchName)
 	if err != nil {
 		return "", err
 	}
@@ -223,17 +223,10 @@ func (gc *GithubClient) ShallowCloneWorktree(org, repoName, cacheDir, worktreeDi
 		return "", err
 	}
 
-	// Only pull if the branch existed on the remote.
-	if remoteExists {
-		pullURL, err := gc.freshTokenURL(org, repoName)
-		if err != nil {
-			return "", err
-		}
-		if err := gc.git.Pull(worktreeDir, pullURL, migrationBranchName); err != nil {
-			return "", err
-		}
-	} else {
-		gc.log.Debug("Migration branch is new, skipping pull in worktree")
+	// Always reset the migration branch to the default branch so every run
+	// produces a clean, deterministic set of commits from the migration YAML.
+	if err := gc.git.ResetToRef(worktreeDir, defaultBranch); err != nil {
+		return "", err
 	}
 
 	return defaultBranch, nil


### PR DESCRIPTION
# What

- Add `ResetToRef(dir, ref string)` to the Git interface — runs `git reset --hard <ref>`
- Wire it through `GithubClient` wrapper and the `githubClient` interface in core
- `ShallowClone` and `ShallowCloneWorktree` now reset the migration branch to the default branch before actions run, replacing the previous Fetch+Pull of the existing migration branch
- `Push` now uses `--force` since the migration branch history diverges after a reset
- Dry-run mode cleans the working tree (`reset --hard HEAD`) between actions so uncommitted changes from one action don't leak into the next action's diff check

# Why

- Re-running a migration (e.g. after adding or reordering actions in the YAML) would produce duplicate commits because Banshee checked out the existing migration branch and replayed all actions on top of previous results
- With reset-and-replay, every run produces a clean, deterministic set of commits derived entirely from the migration YAML — the migration definition is the single source of truth
- Force-push is safe because Banshee owns migration branches exclusively