### PR TITLE
Fix worktree path resolution with git -C

### DIFF
--- a/pkg/gitcli/exec.go
+++ b/pkg/gitcli/exec.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -200,25 +201,32 @@ func (g *ExecGit) Commit(dir, message, authorName, authorEmail string) error {
 // When create=true, a new branch is created (-b). If the worktree already
 // exists (stale from an interrupted run), it is removed and retried.
 func (g *ExecGit) WorktreeAdd(repoDir, worktreeDir, branch string, create bool) error {
-	args := []string{"-C", repoDir, "worktree", "add"}
-	if create {
-		args = append(args, "-b", branch, worktreeDir)
-	} else {
-		args = append(args, worktreeDir, branch)
+	// Resolve worktreeDir to an absolute path so that git -C <repoDir> does
+	// not re-interpret it relative to repoDir.
+	absWT, err := filepath.Abs(worktreeDir)
+	if err != nil {
+		return fmt.Errorf("resolving worktree path: %w", err)
 	}
 
-	_, err := g.run("", args...)
+	args := []string{"-C", repoDir, "worktree", "add"}
+	if create {
+		args = append(args, "-b", branch, absWT)
+	} else {
+		args = append(args, absWT, branch)
+	}
+
+	_, err = g.run("", args...)
 	if isWorktreeExistsErr(err) {
 		// Stale worktree from a previous interrupted run — force-remove,
 		// prune metadata, delete the physical directory, then retry.
 		// WorktreeRemove may fail if git no longer tracks this worktree; that's fine.
-		_, _ = g.run("", "-C", repoDir, "worktree", "remove", "--force", worktreeDir)
+		_, _ = g.run("", "-C", repoDir, "worktree", "remove", "--force", absWT)
 		if _, pruneErr := g.run("", "-C", repoDir, "worktree", "prune"); pruneErr != nil {
 			return fmt.Errorf("pruning stale worktrees before retry: %w", pruneErr)
 		}
 		// Remove the physical directory if it still exists (covers the case
 		// where only the directory remains but git's worktree metadata is gone).
-		_ = os.RemoveAll(worktreeDir)
+		_ = os.RemoveAll(absWT)
 		_, err = g.run("", args...)
 	}
 	return err
@@ -237,7 +245,11 @@ func isWorktreeExistsErr(err error) bool {
 
 // WorktreeRemove forcefully removes a git worktree.
 func (g *ExecGit) WorktreeRemove(repoDir, worktreeDir string) error {
-	_, err := g.run("", "-C", repoDir, "worktree", "remove", "--force", worktreeDir)
+	absWT, err := filepath.Abs(worktreeDir)
+	if err != nil {
+		return fmt.Errorf("resolving worktree path: %w", err)
+	}
+	_, err = g.run("", "-C", repoDir, "worktree", "remove", "--force", absWT)
 	return err
 }
 


### PR DESCRIPTION
# What

- Convert `worktreeDir` to an absolute path via `filepath.Abs()` in `WorktreeAdd` and `WorktreeRemove` before passing it to `git -C <repoDir> worktree add/remove`

# Why

- `git -C <repoDir>` resolves all subsequent relative paths relative to `repoDir`, so the worktree was being created at `repoDir/worktreeDir` (a nested path) instead of `worktreeDir` from the process CWD
- This caused `ResetToRef` (added in #144) to fail with "(no stderr output; git may have exited due to a signal or early EOF)" because `cmd.Dir` pointed to the expected (non-nested) path which didn't exist
- The bug existed since worktree support was added but was masked because the old code skipped `Pull` for new branches — the reset-and-replay change always calls `ResetToRef`, exposing it