### PR TITLE
fix: don't fail a repo when reviewer assignment fails

### DIFF
--- a/.circleci/_config.jsonnet
+++ b/.circleci/_config.jsonnet
@@ -34,7 +34,11 @@ pipeline.new(
                             failfast: true,
                             race: true,
                         }},
-                        steps.run("curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin && golangci-lint run ./...", name='Lint'),
+                        // Pin both the installer script and golangci-lint to a fixed
+                        // version so CI is reproducible and never picks up an untested
+                        // latest release (an unpinned install once pulled a build whose
+                        // checksum failed to verify, breaking the job).
+                        steps.run("curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.2/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.2 && golangci-lint run ./...", name='Lint'),
                     ],
                 )
             ],

--- a/pkg/github/pull_requests.go
+++ b/pkg/github/pull_requests.go
@@ -82,9 +82,15 @@ func (gc *GithubClient) CreatePullRequest(org, repo, title, body, base_branch, m
 
 	gc.log.WithField("AssignReviewers", gc.GlobalConfig.Options.AssignCodeReviewerIfNoneAssigned).Debug("Assigning reviewers, if enabled")
 	if gc.GlobalConfig.Options.AssignCodeReviewerIfNoneAssigned {
-		assignmentErr := gc.AssignDefaultReviewer(pr)
-		if assignmentErr != nil {
-			return "", assignmentErr
+		if assignmentErr := gc.AssignDefaultReviewer(pr); assignmentErr != nil {
+			// Reviewer assignment is best-effort. The pull request already exists at
+			// this point, so a failure here — e.g. the default team can't be resolved
+			// by the authenticated app, or isn't a collaborator on this repo — must not
+			// fail the whole migration for the repo and discard the created PR. Surface
+			// it as a warning and return the PR URL so the run is still reported as OK.
+			gc.log.WithField("pr_url", pr.GetHTMLURL()).Warnf(
+				"could not assign default reviewer %q: %v",
+				gc.GlobalConfig.Defaults.CodeReviewer, assignmentErr)
 		}
 	}
 


### PR DESCRIPTION
## Problem

`CreatePullRequest` opens the PR and then requests the default reviewer team. If that request fails — e.g. the authenticated GitHub App can't resolve the team (missing org **Members: read**), or the team isn't a collaborator on the repo — the error was returned from `CreatePullRequest`, **discarding the created PR's URL and marking the whole repo's migration as failed** even though the PR was created successfully.

Observed in a real 50-repo run: 20 repos reported `FAIL` on `POST .../pulls/<n>/requested_reviewers` (422) despite every one of those PRs existing.

## Fix

Reviewer assignment is best-effort. The PR already exists at that point, so a failure is now logged as a warning and the PR URL is returned, so the run is reported as `OK`.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)